### PR TITLE
Allow setting libusb options

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -203,6 +203,17 @@ impl Context {
             },
         })
     }
+
+    /// Creates a new `libusb` context and sets runtime options.
+    pub fn with_options(opts: &[crate::UsbOption]) -> crate::Result<Self> {
+        let mut this = Self::new()?;
+
+        for opt in opts {
+            opt.apply(&mut this)?;
+        }
+
+        Ok(this)
+    }
 }
 
 extern "C" fn hotplug_callback<T: UsbContext>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub use crate::{
         EndpointDescriptors, Interface, InterfaceDescriptor, InterfaceDescriptors,
     },
     language::{Language, PrimaryLanguage, SubLanguage},
+    options::UsbOption,
     version::{version, LibraryVersion},
 };
 
@@ -41,6 +42,7 @@ mod endpoint_descriptor;
 mod fields;
 mod interface_descriptor;
 mod language;
+mod options;
 
 /// Tests whether the running `libusb` library supports capability API.
 pub fn has_capability() -> bool {

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,39 @@
+use crate::{error, UsbContext};
+use libusb1_sys::{constants::*, libusb_set_option};
+
+/// A `libusb` runtime option that can be enabled for a context.
+pub struct UsbOption {
+    inner: OptionInner,
+}
+
+impl UsbOption {
+    /// Use the [UsbDk] backend if available.
+    ///
+    /// **Note**: This method is available on **Windows** only!
+    ///
+    /// [UsbDk]: https://github.com/daynix/UsbDk
+    #[cfg(windows)]
+    pub fn use_usbdk() -> Self {
+        Self {
+            inner: OptionInner::UseUsbdk,
+        }
+    }
+
+    pub(crate) fn apply<T: UsbContext>(&self, ctx: &mut T) -> crate::Result<()> {
+        match self.inner {
+            OptionInner::UseUsbdk => {
+                let err = unsafe { libusb_set_option(ctx.as_raw(), LIBUSB_OPTION_USE_USBDK) };
+                if err == LIBUSB_SUCCESS {
+                    Ok(())
+                } else {
+                    Err(error::from_libusb(err))
+                }
+            }
+        }
+    }
+}
+
+enum OptionInner {
+    #[cfg_attr(not(windows), allow(dead_code))] // only constructed on Windows
+    UseUsbdk,
+}


### PR DESCRIPTION
The log level could already be set, this is purely to enable setting `LIBUSB_OPTION_USE_USBDK` for use with [UsbDk](https://github.com/daynix/UsbDk) on Windows. This option has to be set right after `libusb_init`, so there's no public way of applying a `UsbOption` to an already opened context.