### PR TITLE
device_handle: Enable automatic kernel driver detachment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ libusb1-sys = "0.3.2"
 libc = "0.2"
 
 [dev-dependencies]
-regex = "0.1"
+regex = "1"

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -118,6 +118,23 @@ impl<T: UsbContext> DeviceHandle<T> {
         Ok(())
     }
 
+    /// Enable/disable automatic kernel driver detachment.
+    ///
+    /// When this is enabled rusb will automatically detach the
+    /// kernel driver on an interface when claiming the interface, and
+    /// attach it when releasing the interface.
+    ///
+    /// On platforms which do not have support, this function will
+    /// return `Error::NotSupported`, and rusb will continue as if
+    /// this function was never called.
+    pub fn set_auto_detach_kernel_driver(&mut self, auto_detach: bool) -> crate::Result<()> {
+        try_unsafe!(libusb_set_auto_detach_kernel_driver(
+            self.handle.as_ptr(),
+            auto_detach.into()
+        ));
+        Ok(())
+    }
+
     /// Claims one of the device's interfaces.
     ///
     /// An interface must be claimed before operating on it. All claimed interfaces are released


### PR DESCRIPTION
When this is enabled libusb will automatically detach the kernel
driver on an interface when claiming the interface, and attach it when
releasing the interface.

Automatic kernel driver detachment is disabled on newly opened device
handles by default.

On platforms which do not have support, this function will return
`Error::NotSupported`, and rusb will continue as if this function was
never called.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>