### PR TITLE
Add vendored feature to force libusb-1.0 build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,12 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "a1ien/rusb" }
 
+[features]
+vendored = [ "libusb1-sys/vendored" ]
+
 [dependencies]
 bit-set = "0.5.0"
-libusb1-sys = "0.3.4"
+libusb1-sys = "0.3.5"
 libc = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
This is related to: https://github.com/a1ien/libusb1-sys/pull/13