### PR TITLE
[#15] Check for bad or empty strings in read_string_descriptor()

### DIFF
--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -580,7 +580,8 @@ impl<T: UsbContext> DeviceHandle<T> {
         )?;
 
         if len < 2 || buf[0] != len as u8 || len & 0x01 != 0 {
-            return Err(Error::BadDescriptor);
+            // Consider making this `Error::BadDescriptor` on next breaking change.
+            return Err(Error::Other);
         }
 
         if len == 2 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,9 @@ pub enum Error {
     /// Operation not supported or unimplemented on this platform.
     NotSupported,
 
+    /// The device returned a malformed descriptor
+    BadDescriptor,
+
     /// Other error.
     Other,
 }
@@ -68,6 +71,7 @@ impl Error {
             Error::Interrupted => "System call interrupted (perhaps due to signal)",
             Error::NoMem => "Insufficient memory",
             Error::NotSupported => "Operation not supported or unimplemented on this platform",
+            Error::BadDescriptor => "Malformed descriptor",
             Error::Other => "Other error",
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,8 +47,10 @@ pub enum Error {
     /// Operation not supported or unimplemented on this platform.
     NotSupported,
 
+    /* Consider adding this on next breaking change (v0.6?)
     /// The device returned a malformed descriptor
     BadDescriptor,
+    */
 
     /// Other error.
     Other,
@@ -71,7 +73,7 @@ impl Error {
             Error::Interrupted => "System call interrupted (perhaps due to signal)",
             Error::NoMem => "Insufficient memory",
             Error::NotSupported => "Operation not supported or unimplemented on this platform",
-            Error::BadDescriptor => "Malformed descriptor",
+            //Error::BadDescriptor => "Malformed descriptor",
             Error::Other => "Other error",
         }
     }


### PR DESCRIPTION
Adds some sanity checks on the string descriptor returned by a device before trying to parse the string. For example, the byte length should be even since the unicode string has 2-bytes per char.

This also checks for an empty string, in which `len == 2` is just for the header, with zero bytes for the string. This succeeds and returns an empty string.