### PR TITLE
Removed unsafe buf_slice from read_string_descriptor_ascii()

### DIFF
--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -552,7 +552,10 @@ impl<T: UsbContext> DeviceHandle<T> {
             return Err(Error::Other);
         }
 
-        buf.resize(res as usize, 0u8);
+        unsafe {
+            buf.set_len(res as usize);
+        }
+
         String::from_utf8(buf).map_err(|_| Error::Other)
     }
 

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -540,22 +540,19 @@ impl<T: UsbContext> DeviceHandle<T> {
     pub fn read_string_descriptor_ascii(&self, index: u8) -> crate::Result<String> {
         let mut buf = Vec::<u8>::with_capacity(255);
 
-        let buf_slice = unsafe { slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity()) };
-
-        let ptr = buf_slice.as_mut_ptr() as *mut c_uchar;
-        let len = buf_slice.len() as i32;
+        let ptr = buf.as_mut_ptr() as *mut c_uchar;
+        let len = buf.len() as i32;
 
         let res =
             unsafe { libusb_get_string_descriptor_ascii(self.handle.as_ptr(), index, ptr, len) };
 
         if res < 0 {
             return Err(error::from_libusb(res));
+        } else if res > len {
+            return Err(Error::Other);
         }
 
-        unsafe {
-            buf.set_len(res as usize);
-        }
-
+        buf.resize(res as usize, 0u8);
         String::from_utf8(buf).map_err(|_| Error::Other)
     }
 

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -548,8 +548,6 @@ impl<T: UsbContext> DeviceHandle<T> {
 
         if res < 0 {
             return Err(error::from_libusb(res));
-        } else if res > len {
-            return Err(Error::Other);
         }
 
         unsafe {


### PR DESCRIPTION
Minor update. This just removes some unsafe code from `read_string_descriptor_ascii()`, like what was done in #16 and #17.