### PR TITLE
error: Avoid consuming the `Error` when returning the error string

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -58,7 +58,7 @@ pub enum Error {
 
 impl Error {
     /// Returns a description of an error suitable for display to an end user.
-    pub fn strerror(self) -> &'static str {
+    pub fn strerror(&self) -> &'static str {
         match self {
             Error::Success => "Success",
             Error::Io => "Input/Output Error",


### PR DESCRIPTION
This workaroud an issue we found when supporting a customer which the
lib triggered a segfault when displaying a error on 32bits platforms.

We reported the issue to Rust compiler, but the workaroud is indeed good
as even when this gets fixed on newer releases of the compiler, old
versions will still be affected and this is a very difficult kind of bug
to find.

Refs: https://github.com/rust-lang/rust/issues/73151
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>