### PR TITLE
device_handle: replace BitSet with new struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "a1ien/rusb" }
 vendored = [ "libusb1-sys/vendored" ]
 
 [dependencies]
-bit-set = "0.5.0"
 libusb1-sys = "0.3.5"
 libc = "0.2"
 


### PR DESCRIPTION
Create a new struct, ClaimedInterfaces, which is responsible for
tracking the claimed interfaces of a particular DeviceHandle.

Add tests for ClaimedInterfaces.

Replace usages of BitSet with this ClaimedInterfaces struct within
DeviceHandle.

Remove dependency on bit-set from the crate.

Fixes #29 