### PR TITLE
Make from_libusb public so Android users can create devices as non-root users

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "a1ien/rusb" }
 vendored = [ "libusb1-sys/vendored" ]
 
 [dependencies]
-libusb1-sys = "0.4.1"
+libusb1-sys = { path = "/home/bgardner/workspace/libusb1-sys" }
 libc = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "a1ien/rusb" }
 vendored = [ "libusb1-sys/vendored" ]
 
 [dependencies]
-libusb1-sys = { path = "/home/bgardner/workspace/libusb1-sys" }
+libusb1-sys = { path = "../libusb1-sys" }
 libc = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "a1ien/rusb" }
 vendored = [ "libusb1-sys/vendored" ]
 
 [dependencies]
-libusb1-sys = { path = "/home/bgardner/workspace/libusb1-sys" }
+libusb1-sys = "0.4.1"
 libc = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusb"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "Rust library for accessing USB devices."
 license = "MIT"
@@ -17,7 +17,7 @@ travis-ci = { repository = "a1ien/rusb" }
 vendored = [ "libusb1-sys/vendored" ]
 
 [dependencies]
-libusb1-sys = "0.3.5"
+libusb1-sys = { path = "/home/bgardner/workspace/libusb1-sys" }
 libc = "0.2"
 
 [dev-dependencies]

--- a/src/context.rs
+++ b/src/context.rs
@@ -224,7 +224,7 @@ extern "system" fn hotplug_callback<T: UsbContext>(
 ) -> c_int {
     unsafe {
         let mut reg = Box::<CallbackData<T>>::from_raw(reg as _);
-        let device = device::from_libusb(reg.context.clone(), device);
+        let device = device::Device::from_libusb(reg.context.clone(), device);
         match event {
             LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED => reg.hotplug.device_arrived(device),
             LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT => reg.hotplug.device_left(device),

--- a/src/context.rs
+++ b/src/context.rs
@@ -81,7 +81,7 @@ pub trait UsbContext: Clone + Sized {
         if handle.is_null() {
             None
         } else {
-            Some(unsafe { device_handle::from_libusb(self.clone(), handle) })
+            Some(unsafe { DeviceHandle::from_libusb(self.clone(), handle) })
         }
     }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -132,7 +132,7 @@ impl<T: UsbContext> Device<T> {
 
         try_unsafe!(libusb_open(self.device.as_ptr(), handle.as_mut_ptr()));
 
-        Ok(unsafe { device_handle::from_libusb(self.context.clone(), handle.assume_init()) })
+        Ok(unsafe { DeviceHandle::from_libusb(self.context.clone(), handle.assume_init()) })
     }
 
     /// Returns the device's port number

--- a/src/device.rs
+++ b/src/device.rs
@@ -58,6 +58,19 @@ impl<T: UsbContext> Device<T> {
         self.device.as_ptr()
     }
 
+    /// Unsafe function to convert an existing libusb_device into a Device<T>. Useful for Android.
+    pub unsafe fn from_libusb(
+        context: T,
+        device: *mut libusb_device,
+    ) -> Device<T> {
+        libusb_ref_device(device);
+
+        Device {
+            context,
+            device: NonNull::new_unchecked(device),
+        }
+    }
+
     /// Reads the device descriptor.
     pub fn device_descriptor(&self) -> crate::Result<DeviceDescriptor> {
         let mut descriptor = mem::MaybeUninit::<libusb_device_descriptor>::uninit();
@@ -125,18 +138,5 @@ impl<T: UsbContext> Device<T> {
     /// Returns the device's port number
     pub fn port_number(&self) -> u8 {
         unsafe { libusb_get_port_number(self.device.as_ptr()) }
-    }
-}
-
-#[doc(hidden)]
-pub(crate) unsafe fn from_libusb<T: UsbContext>(
-    context: T,
-    device: *mut libusb_device,
-) -> Device<T> {
-    libusb_ref_device(device);
-
-    Device {
-        context,
-        device: NonNull::new_unchecked(device),
     }
 }

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -146,6 +146,18 @@ impl<T: UsbContext> DeviceHandle<T> {
         }
     }
 
+    /// Unsafe function to convert an existing libusb_device_handle into a DeviceHandle<T>. Useful for Android.
+    pub unsafe fn from_libusb(
+        context: T,
+        handle: *mut libusb_device_handle,
+    ) -> DeviceHandle<T> {
+        DeviceHandle {
+            context: context,
+            handle: NonNull::new_unchecked(handle),
+            interfaces: ClaimedInterfaces::new(),
+        }
+    }
+
     /// Returns the active configuration number.
     pub fn active_configuration(&self) -> crate::Result<u8> {
         let mut config = mem::MaybeUninit::<c_int>::uninit();
@@ -782,18 +794,6 @@ impl<T: UsbContext> DeviceHandle<T> {
             None => Err(Error::InvalidParam),
             Some(n) => self.read_string_descriptor(language, n, timeout),
         }
-    }
-}
-
-#[doc(hidden)]
-pub(crate) unsafe fn from_libusb<T: UsbContext>(
-    context: T,
-    handle: *mut libusb_device_handle,
-) -> DeviceHandle<T> {
-    DeviceHandle {
-        context: context,
-        handle: NonNull::new_unchecked(handle),
-        interfaces: ClaimedInterfaces::new(),
     }
 }
 

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -139,7 +139,7 @@ impl<T: UsbContext> DeviceHandle<T> {
     /// Get the device associated to this handle
     pub fn device(&self) -> Device<T> {
         unsafe {
-            device::from_libusb(
+            device::Device::from_libusb(
                 self.context.clone(),
                 libusb_get_device(self.handle.as_ptr()),
             )

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -102,7 +102,7 @@ impl<'a, T: UsbContext> Iterator for Devices<'a, T> {
             let device = self.devices[self.index];
 
             self.index += 1;
-            Some(unsafe { device::from_libusb(self.context.clone(), device) })
+            Some(unsafe { device::Device::from_libusb(self.context.clone(), device) })
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,6 @@ pub fn open_device_with_vid_pid(
     if handle.is_null() {
         None
     } else {
-        Some(unsafe { device_handle::from_libusb(GlobalContext::default(), handle) })
+        Some(unsafe { DeviceHandle::from_libusb(GlobalContext::default(), handle) })
     }
 }


### PR DESCRIPTION
By default, Android sets `/dev/bus/usb` to be only accessible to `root` and `usb`. Unfortunately, Andriod applications each get their own user, and that users isn't a member of the `usb` group, so opening devices on Android fails from libusb unless run as root from the `adb shell` command line. When running as an apk the open call fails.

However, applications can open USB devices from the [Java API](https://developer.android.com/reference/android/hardware/usb/UsbManager#openDevice(android.hardware.usb.UsbDevice)) and from there they can get a [file descriptor](https://developer.android.com/reference/android/hardware/usb/UsbDeviceConnection#getFileDescriptor()) and pass that to [libusb1-sys](https://github.com/a1ien/libusb1-sys/blob/377a8ac5c95861528472160970ee43fadab01d30/src/lib.rs#L269) and finally to `rusb::Device::from_libusb()` in order to get a device.

I know this sounds convoluted, and it is, but it does allow lots of Android developers to start using this library, including myself. I look forward to your review and feedback.

Thanks,

- Brent