### PR TITLE
Expose from_libusb() methods to import devices from Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusb"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "Rust library for accessing USB devices."
 license = "MIT"
@@ -17,7 +17,7 @@ travis-ci = { repository = "a1ien/rusb" }
 vendored = [ "libusb1-sys/vendored" ]
 
 [dependencies]
-libusb1-sys = "0.3.5"
+libusb1-sys = "0.4.1"
 libc = "0.2"
 
 [dev-dependencies]

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -102,7 +102,7 @@ impl<'a, T: UsbContext> Iterator for Devices<'a, T> {
             let device = self.devices[self.index];
 
             self.index += 1;
-            Some(unsafe { device::from_libusb(self.context.clone(), device) })
+            Some(unsafe { device::Device::from_libusb(self.context.clone(), std::ptr::NonNull::new_unchecked(device)) })
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,6 @@ pub fn open_device_with_vid_pid(
     if handle.is_null() {
         None
     } else {
-        Some(unsafe { device_handle::from_libusb(GlobalContext::default(), handle) })
+        Some(unsafe { DeviceHandle::from_libusb(GlobalContext::default(), std::ptr::NonNull::new_unchecked(handle)) })
     }
 }


### PR DESCRIPTION
Sorry for the 2nd PR, but I had to fight some libusb bugs to confirm this works, and it does!

With this PR, folks can use rust on Android as non-root users.