### PR TITLE
Update to always point at latest libusb1-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "a1ien/rusb" }
 vendored = [ "libusb1-sys/vendored" ]
 
 [dependencies]
-libusb1-sys = "0.4.1"
+libusb1-sys = "0.4"
 libc = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
This should prevent having to re-release this crate every time the libusb1-sys dependency changes, as long as semver is followed by libusb1-sys, this shouldn't break existing builds.