### PR TITLE
Fix Unsound Send/Sync bound for Device and DeviceHandle

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -48,7 +48,7 @@ pub trait Hotplug<T: UsbContext> {
 
 pub type Registration = c_int;
 
-pub trait UsbContext: Clone + Sized {
+pub trait UsbContext: Clone + Sized + Send + Sync {
     /// Get the raw libusb_context pointer, for advanced use in unsafe code.
     fn as_raw(&self) -> *mut libusb_context;
 


### PR DESCRIPTION
As mention #44 UsbContext trait has neither Send nor Sync bound and can be implemented from the user side. This permits writing a custom non-thread safe UsbContext implementation in safe Rust code, which can cause a data race when used with Device or DeviceHandle.
So required UsbContext implement Send + Sync

Fix #44 