### PR TITLE
Async

### DIFF
--- a/src/async_interface.rs
+++ b/src/async_interface.rs
@@ -1,0 +1,109 @@
+
+use std::collections::VecDeque;
+use std::pin::Pin;
+
+use libc::c_void;
+use libusb1_sys::libusb_transfer;
+
+use crate::Context;
+use crate::DeviceHandle;
+
+#[derive(Debug)]
+pub enum TransferStatus {
+	Completed(Vec<u8>),
+	Error,
+	TimedOut,
+	Stall,
+	NoDevice,
+	Overflow,
+	Unknown(i32)
+}
+
+// Putting the libusb_transfer pointer and the buffer in the struct that owns both ties the lifetimes
+// together and ensures that `buff` will live as long as `ptr`.  We also know that the receiving VecDeque
+// will live as long as the pointer and buffer because it's owned by the same struct.  We put the pointer
+// inside `recv` to the `libusb_transfer` struct, so it's important for `recv` to stay at the same address,
+// which is why it's wrapped in a Pin<_>
+// This is not thread-safe at all.  If you try to implement Send or Sync on it, it'll have to be an unsafe impl.
+pub struct AsyncTransfer {
+	pub ptr: *mut libusb_transfer,
+	pub buff: Vec<u8>,
+	pub recv: Pin<Box<VecDeque<TransferStatus>>>,
+}
+
+impl AsyncTransfer {
+
+	extern "system" fn callback(xfer_ptr: *mut libusb_transfer) {
+
+		unsafe {
+			let xfer = match (*xfer_ptr).status {
+				0 => {
+					// Clone the memory into a vector
+					let slice:&[u8] = std::slice::from_raw_parts((*xfer_ptr).buffer, (*xfer_ptr).actual_length as usize);
+					TransferStatus::Completed(slice.to_vec())
+				},
+				1 => TransferStatus::Error,
+				2 => TransferStatus::TimedOut,
+				3 => TransferStatus::Stall,
+				4 => TransferStatus::NoDevice,
+				5 => TransferStatus::Overflow,
+				n => TransferStatus::Unknown(n),
+			};
+
+			// Update the parser stored in the user data field
+			let xfer_deque:*mut VecDeque<TransferStatus> = (*xfer_ptr).user_data as *mut VecDeque<TransferStatus>;
+			(*xfer_deque).push_back(xfer);
+
+			// Resubmit the transfer
+			assert!(libusb1_sys::libusb_submit_transfer(xfer_ptr) == 0);
+		}
+
+	}
+
+	pub fn bulk(handle: &mut DeviceHandle<Context>, addr:u8) -> Self {
+
+		// The steps in the comments follow the steps described in the libusb documentation
+
+		// Step 1: Allocation		
+		let ptr:*mut libusb_transfer = unsafe{ libusb1_sys::libusb_alloc_transfer(0) };
+		let mut buff:Vec<u8> = vec![0u8; 256];
+		assert!(!ptr.is_null());
+
+		let mut user_data = Box::new(VecDeque::new());
+
+		// Step 2: Filling
+		let default_timeout_ms = 1000;
+		unsafe {
+			let rp_ptr:&mut VecDeque<TransferStatus> = &mut user_data;
+			libusb1_sys::libusb_fill_bulk_transfer(ptr, handle.as_raw(), addr,
+				buff.as_mut_ptr(), buff.len() as i32, Self::callback, 
+				rp_ptr as *mut VecDeque<TransferStatus> as *mut c_void, default_timeout_ms);
+		}
+
+		// Step 3: Submission
+		unsafe {
+			assert!(libusb1_sys::libusb_submit_transfer(ptr) == 0);
+		}
+
+		// Pin protects the location in memory by making possible to access the data in the
+		// pointer type, but not possible to get the actual location in memory.  You can't
+		// move it if you don't know where it is.  We got the location in memory before we
+		// wrapped this pointer in a Pin<_> so that we could populate the bulk transfer.  Now
+		// we know it's going to stay there until the memory gets freed.
+		let recv:Pin<Box<VecDeque<TransferStatus>>> = Pin::new(user_data);
+
+		Self{ ptr, buff, recv }
+	}
+
+}
+
+impl std::ops::Drop for AsyncTransfer {
+
+	fn drop(&mut self) {
+		unsafe{ libusb1_sys::libusb_free_transfer(self.ptr); }
+	}
+
+}
+
+
+

--- a/src/async_interface.rs
+++ b/src/async_interface.rs
@@ -100,7 +100,10 @@ impl AsyncTransfer {
 impl std::ops::Drop for AsyncTransfer {
 
 	fn drop(&mut self) {
-		unsafe{ libusb1_sys::libusb_free_transfer(self.ptr); }
+		unsafe{ 
+			libusb1_sys::libusb_cancel_transfer(self.ptr);
+			libusb1_sys::libusb_free_transfer(self.ptr); 
+		}
 	}
 
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -204,6 +204,9 @@ struct CallbackData<T: UsbContext> {
 impl Context {
     /// Opens a new `libusb` context.
     pub fn new() -> crate::Result<Self> {
+
+        eprintln!("Context::new() from async branch of rusb repo");
+        
         let mut context = mem::MaybeUninit::<*mut libusb_context>::uninit();
 
         try_unsafe!(libusb_init(context.as_mut_ptr()));
@@ -219,7 +222,7 @@ impl Context {
 
     /// Get the raw libusb_context pointer, for advanced use in unsafe code.
     pub fn as_raw(&self) -> *mut libusb_context {
-        self.inner.as_ptr()
+        self.context.inner.as_ptr()
     }
 
     /// Creates a new `libusb` context and sets runtime options.

--- a/src/context.rs
+++ b/src/context.rs
@@ -217,6 +217,11 @@ impl Context {
         })
     }
 
+    /// Get the raw libusb_context pointer, for advanced use in unsafe code.
+    pub fn as_raw(&self) -> *mut libusb_context {
+        self.inner.as_ptr()
+    }
+
     /// Creates a new `libusb` context and sets runtime options.
     pub fn with_options(opts: &[crate::UsbOption]) -> crate::Result<Self> {
         let mut this = Self::new()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub use libusb1_sys::constants;
 
 pub use crate::{
+    async_interface::{TransferStatus, AsyncTransfer},
     config_descriptor::{ConfigDescriptor, Interfaces},
     context::{Context, GlobalContext, Hotplug, LogLevel, Registration, UsbContext},
     device::Device,
@@ -43,6 +44,8 @@ mod fields;
 mod interface_descriptor;
 mod language;
 mod options;
+
+mod async_interface;
 
 /// Tests whether the running `libusb` library supports capability API.
 pub fn has_capability() -> bool {


### PR DESCRIPTION
This is an attempt at making the async API work.  It's not complete yet and only includes bulk receive right now, but if nobody sees anything wrong with the basic idea, it'll be pretty straightforward to fill in the other types of transfers.  The whole thing revolves around a struct called `AsyncTransfer`.  It contains a raw pointer to a `libusb_transfer` from libusb, a buffer for receiving data, and a buffer for completed transfers.  

TODO: I made all the struct members public for debugging, but I just realized these should probably all be private.  We could create a `pop_front` function on this struct that takes `&mut self` and just calls `pop_front` on `recv`.  That's the only function the owning scope should need after the struct is created.

For this to work, all three of these need to have the same lifetime and making them all owned by the same struct accomplishes this. We also use Pin for the VecDeque that collects the results because a pointer to this is passed to the libusb transfer struct as the user data, so it needs to maintain the same location in memory for as long as it lives.

```
pub struct AsyncTransfer {
	pub ptr: *mut libusb_transfer,
	pub buff: Vec<u8>,
	pub recv: Pin<Box<VecDeque<TransferStatus>>>,
}
```

The `buff` vector is the vector where libusb puts the data.  `ptr` is the transfer struct provided by libusb.  `recv` is where we accumulate the results.  `TransferStatus` looks like this:

```
pub enum TransferStatus {
	Completed(Vec<u8>),
	Error,
	TimedOut,
	Stall,
	NoDevice,
	Overflow,
	Unknown(i32)
}
```
The callback function is a private function inside `impl AsynTransfer` and looks like this:

```
	extern "system" fn callback(xfer_ptr: *mut libusb_transfer) {

		unsafe {
			let xfer = match (*xfer_ptr).status {
				0 => {
					// Clone the memory into a vector
					let slice:&[u8] = std::slice::from_raw_parts((*xfer_ptr).buffer, (*xfer_ptr).actual_length as usize);
					TransferStatus::Completed(slice.to_vec())
				},
				1 => TransferStatus::Error,
				2 => TransferStatus::TimedOut,
				3 => TransferStatus::Stall,
				4 => TransferStatus::NoDevice,
				5 => TransferStatus::Overflow,
				n => TransferStatus::Unknown(n),
			};

			// Update the parser stored in the user data field
			let xfer_deque:*mut VecDeque<TransferStatus> = (*xfer_ptr).user_data as *mut VecDeque<TransferStatus>;
			(*xfer_deque).push_back(xfer);

			// Resubmit the transfer
			assert!(libusb1_sys::libusb_submit_transfer(xfer_ptr) == 0);
		}

	}
```

Basically, it puts the result into a `VecDeque` and the scope that owns the struct can process these whenever it wants.  This is not threadsafe, but doesn't pretend to be.  If you try to make this struct `Send` or `Sync`, the compiler gives an error.  The callback function runs in the same thread that created the struct when you call `libusb1_sys::libusb_handle_events`.