### PR TITLE
Add Device/DeviceHandle::context getter methods

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -59,6 +59,11 @@ impl<T: UsbContext> Device<T> {
         self.device.as_ptr()
     }
 
+    /// Get the context associated with this device
+    pub fn context(&self) -> &T {
+        &self.context
+    }
+
     /// # Safety
     ///
     /// Converts an existing `libusb_device` pointer into a `Device<T>`.

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -136,6 +136,11 @@ impl<T: UsbContext> DeviceHandle<T> {
         self.handle.as_ptr()
     }
 
+    /// Get the context associated with this device
+    pub fn context(&self) -> &T {
+        &self.context
+    }
+
     /// Get the device associated to this handle
     pub fn device(&self) -> Device<T> {
         unsafe {


### PR DESCRIPTION
I'm experimenting with abstractions for the libusb async APIs that don't necessarily belong in the `rusb` crate itself. It would be nice if these APIs could accept a `DeviceHandle` and not also need to have the `Context` passed separately for the `libusb_handle_events*` functions.