### PR TITLE
Add Bulk transfer async API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = ["libusb1-sys"]
 libusb1-sys = { path = "libusb1-sys", version = "0.5.0" }
 libc = "0.2"
 log = "0.4"
+thiserror = "1"
 
 [dev-dependencies]
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "rusb"
 version = "0.8.0"
-authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
+authors = [
+    "David Cuddeback <david.cuddeback@gmail.com>",
+    "Ilya Averyanov <a1ien.n3t@gmail.com>",
+]
 description = "Rust library for accessing USB devices."
 license = "MIT"
 homepage = "https://github.com/a1ien/rusb"
@@ -15,7 +18,7 @@ build = "build.rs"
 travis-ci = { repository = "a1ien/rusb" }
 
 [features]
-vendored = [ "libusb1-sys/vendored" ]
+vendored = ["libusb1-sys/vendored"]
 
 [workspace]
 members = ["libusb1-sys"]
@@ -23,6 +26,7 @@ members = ["libusb1-sys"]
 [dependencies]
 libusb1-sys = { path = "libusb1-sys", version = "0.5.0" }
 libc = "0.2"
+log = "0.4"
 
 [dev-dependencies]
 regex = "1"

--- a/examples/read_async.rs
+++ b/examples/read_async.rs
@@ -1,0 +1,42 @@
+use rusb::{AsyncTransfer, CbResult, Context, UsbContext};
+
+use std::str::FromStr;
+use std::time::Duration;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() < 4 {
+        eprintln!("Usage: read_async <vendor-id> <product-id> <endpoint>");
+        return;
+    }
+
+    let vid: u16 = FromStr::from_str(args[1].as_ref()).unwrap();
+    let pid: u16 = FromStr::from_str(args[2].as_ref()).unwrap();
+    let endpoint: u8 = FromStr::from_str(args[3].as_ref()).unwrap();
+
+    let ctx = Context::new().expect("Could not initialize libusb");
+    let device = ctx
+        .open_device_with_vid_pid(vid, pid)
+        .expect("Could not find device");
+
+    const NUM_TRANSFERS: usize = 32;
+    const BUF_SIZE: usize = 1024;
+    let mut main_buffer = Box::new([0u8; BUF_SIZE * NUM_TRANSFERS]);
+
+    let mut transfers = Vec::new();
+    for buf in main_buffer.chunks_exact_mut(BUF_SIZE) {
+        let mut transfer =
+            AsyncTransfer::new_bulk(&device, endpoint, buf, callback, Duration::from_secs(10));
+        transfer.submit().expect("Could not submit transfer");
+        transfers.push(transfer);
+    }
+
+    loop {
+        rusb::poll_transfers(&ctx, Duration::from_secs(10));
+    }
+}
+
+fn callback(result: CbResult) {
+    println!("{:?}", result)
+}

--- a/examples/read_async.rs
+++ b/examples/read_async.rs
@@ -22,12 +22,16 @@ fn main() {
 
     const NUM_TRANSFERS: usize = 32;
     const BUF_SIZE: usize = 1024;
-    let mut main_buffer = Box::new([0u8; BUF_SIZE * NUM_TRANSFERS]);
 
     let mut transfers = Vec::new();
-    for buf in main_buffer.chunks_exact_mut(BUF_SIZE) {
-        let mut transfer =
-            AsyncTransfer::new_bulk(&device, endpoint, buf, callback, Duration::from_secs(10));
+    for _ in 0..NUM_TRANSFERS {
+        let mut transfer = AsyncTransfer::new_bulk(
+            &device,
+            endpoint,
+            BUF_SIZE,
+            callback,
+            Duration::from_secs(10),
+        );
         transfer.submit().expect("Could not submit transfer");
         transfers.push(transfer);
     }

--- a/src/device_handle/async_api.rs
+++ b/src/device_handle/async_api.rs
@@ -195,8 +195,8 @@ impl<C: UsbContext, F> Drop for AsyncTransfer<'_, '_, C, F> {
 /// given timeout, or return immediately if timeout is zero.
 pub fn poll_transfers(ctx: &impl UsbContext, timeout: Duration) {
     let timeval = libc::timeval {
-        tv_sec: timeout.as_secs() as i64,
-        tv_usec: timeout.subsec_millis() as i64,
+        tv_sec: timeout.as_secs().try_into().unwrap(),
+        tv_usec: timeout.subsec_millis().try_into().unwrap(),
     };
     unsafe {
         ffi::libusb_handle_events_timeout_completed(

--- a/src/device_handle/async_api.rs
+++ b/src/device_handle/async_api.rs
@@ -1,0 +1,93 @@
+use crate::{DeviceHandle, UsbContext};
+
+use libc::c_void;
+use libusb1_sys as ffi;
+
+use std::convert::{TryFrom, TryInto};
+use std::marker::{PhantomData, PhantomPinned};
+use std::pin::Pin;
+use std::ptr::NonNull;
+
+struct AsyncTransfer<'d, 'b, C: UsbContext, F: FnMut()> {
+    ptr: *mut ffi::libusb_transfer,
+    buf: &'b mut [u8],
+    closure: F,
+    _pin: PhantomPinned, // `ptr` holds a ptr to `buf` and `callback`, so we must ensure that we don't move
+    _device: PhantomData<&'d DeviceHandle<C>>,
+}
+impl<'d, 'b, C: UsbContext, F: FnMut()> AsyncTransfer<'d, 'b, C, F> {
+    pub fn new_bulk(
+        device: &'d DeviceHandle<C>,
+        endpoint: u8,
+        buffer: &'b mut [u8],
+        callback: F,
+        timeout: std::time::Duration,
+    ) -> Pin<Box<Self>> {
+        // non-isochronous endpoints (e.g. control, bulk, interrupt) specify a value of 0
+        let ptr = unsafe { ffi::libusb_alloc_transfer(0) };
+        let ptr = NonNull::new(ptr).expect("Could not allocate transfer!");
+        let timeout = libc::c_uint::try_from(timeout.as_millis())
+            .expect("Duration was too long to fit into a c_uint");
+
+        // Safety: Pinning `result` ensures it doesn't move, but we know that we will
+        // want to access its fields mutably, we just don't want its memory location
+        // changing (or its fields moving!). So routinely we will unsafely interact with
+        // its fields mutably through a shared reference, but this is still sound.
+        let result = Box::pin(Self {
+            ptr: std::ptr::null_mut(),
+            buf: buffer,
+            closure: callback,
+            _pin: PhantomPinned,
+            _device: PhantomData,
+        });
+
+        let closure_as_ptr: *mut F = {
+            let mut_ref: *const F = &result.closure;
+            mut_ref as *mut F
+        };
+        unsafe {
+            ffi::libusb_fill_bulk_transfer(
+                ptr.as_ptr(),
+                device.as_raw(),
+                endpoint,
+                result.buf.as_ptr() as *mut u8,
+                result.buf.len().try_into().unwrap(),
+                Self::transfer_cb,
+                closure_as_ptr as *mut c_void,
+                timeout,
+            )
+        };
+        result
+    }
+
+    // We need to invoke our closure using a c-style function, so we store the closure
+    // inside the custom user data field of the transfer struct, and then call the
+    // user provided closure from there.
+    extern "system" fn transfer_cb(transfer: *mut ffi::libusb_transfer) {
+        // Safety: libusb should never make this null, so this is fine
+        let transfer = unsafe { &mut *transfer };
+
+        // sanity
+        debug_assert_eq!(
+            transfer.transfer_type,
+            ffi::constants::LIBUSB_TRANSFER_TYPE_BULK
+        );
+
+        // sanity
+        debug_assert_eq!(
+            std::mem::size_of::<*mut F>(),
+            std::mem::size_of::<*mut c_void>(),
+        );
+        // Safety: The pointer shouldn't be a fat pointer, and should be valid, so
+        // this should be fine
+        let closure = unsafe {
+            let closure: *mut F = std::mem::transmute(transfer.user_data);
+            &mut *closure
+        };
+
+        // TODO: check some stuff
+
+        // call user callback
+        (*closure)();
+    }
+}

--- a/src/device_handle/mod.rs
+++ b/src/device_handle/mod.rs
@@ -1,3 +1,5 @@
+mod async_api;
+
 use std::{mem, ptr::NonNull, time::Duration, u8};
 
 use libc::{c_int, c_uchar, c_uint};

--- a/src/device_handle/mod.rs
+++ b/src/device_handle/mod.rs
@@ -1,4 +1,4 @@
-mod async_api;
+pub mod async_api;
 
 use std::{mem, ptr::NonNull, time::Duration, u8};
 

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -102,7 +102,12 @@ impl<'a, T: UsbContext> Iterator for Devices<'a, T> {
             let device = self.devices[self.index];
 
             self.index += 1;
-            Some(unsafe { device::Device::from_libusb(self.context.clone(), std::ptr::NonNull::new_unchecked(device)) })
+            Some(unsafe {
+                device::Device::from_libusb(
+                    self.context.clone(),
+                    std::ptr::NonNull::new_unchecked(device),
+                )
+            })
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub use crate::{
     context::{Context, GlobalContext, Hotplug, LogLevel, Registration, UsbContext},
     device::Device,
     device_descriptor::DeviceDescriptor,
+    device_handle::async_api::{poll_transfers, AsyncTransfer, CbResult},
     device_handle::DeviceHandle,
     device_list::{DeviceList, Devices},
     endpoint_descriptor::EndpointDescriptor,
@@ -106,6 +107,11 @@ pub fn open_device_with_vid_pid(
     if handle.is_null() {
         None
     } else {
-        Some(unsafe { DeviceHandle::from_libusb(GlobalContext::default(), std::ptr::NonNull::new_unchecked(handle)) })
+        Some(unsafe {
+            DeviceHandle::from_libusb(
+                GlobalContext::default(),
+                std::ptr::NonNull::new_unchecked(handle),
+            )
+        })
     }
 }


### PR DESCRIPTION
Closes #62 

Disclaimer: I am very new to unsafe rust, self-referential structs, and libusb's async API. **Please vet this code.**

This WIP PR adds support for bulk reads with libusb's async API. The following needs to be done before a merge:

- [ ] Does this API look good for handling async transfers? Is it ergonomic? Does it need any changes to support other transfer types other than bulk if we add those in the future?
- [ ] Add some example usage
- [ ] Real-world validation
- [ ] Compare performance to sync api
- [ ] Potentially feature gate and state that we provide no stability guarantees for it, so we can iterate on it without bumping major version? That way we can get some feedback on it in real world use?