### PR TITLE
Async api, take 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "rusb"
 version = "0.8.0"
-authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
+authors = [
+    "David Cuddeback <david.cuddeback@gmail.com>",
+    "Ilya Averyanov <a1ien.n3t@gmail.com>",
+]
 description = "Rust library for accessing USB devices."
 license = "MIT"
 homepage = "https://github.com/a1ien/rusb"
@@ -15,7 +18,7 @@ build = "build.rs"
 travis-ci = { repository = "a1ien/rusb" }
 
 [features]
-vendored = [ "libusb1-sys/vendored" ]
+vendored = ["libusb1-sys/vendored"]
 
 [workspace]
 members = ["libusb1-sys"]
@@ -23,6 +26,8 @@ members = ["libusb1-sys"]
 [dependencies]
 libusb1-sys = { path = "libusb1-sys", version = "0.5.0" }
 libc = "0.2"
+log = "0.4"
+thiserror = "1"
 
 [dev-dependencies]
 regex = "1"

--- a/examples/read_async.rs
+++ b/examples/read_async.rs
@@ -1,0 +1,46 @@
+use rusb::{AsyncTransfer, CbResult, Context, UsbContext};
+
+use std::str::FromStr;
+use std::time::Duration;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() < 4 {
+        eprintln!("Usage: read_async <vendor-id> <product-id> <endpoint>");
+        return;
+    }
+
+    let vid: u16 = FromStr::from_str(args[1].as_ref()).unwrap();
+    let pid: u16 = FromStr::from_str(args[2].as_ref()).unwrap();
+    let endpoint: u8 = FromStr::from_str(args[3].as_ref()).unwrap();
+
+    let ctx = Context::new().expect("Could not initialize libusb");
+    let device = ctx
+        .open_device_with_vid_pid(vid, pid)
+        .expect("Could not find device");
+
+    const NUM_TRANSFERS: usize = 32;
+    const BUF_SIZE: usize = 1024;
+
+    let mut transfers = Vec::new();
+    for _ in 0..NUM_TRANSFERS {
+        let mut transfer = AsyncTransfer::new_bulk(
+            &device,
+            endpoint,
+            BUF_SIZE,
+            callback,
+            Duration::from_secs(10),
+        );
+        transfer.submit().expect("Could not submit transfer");
+        transfers.push(transfer);
+    }
+
+    loop {
+        rusb::poll_transfers(&ctx, Duration::from_secs(10));
+    }
+}
+
+fn callback(result: CbResult) {
+    println!("{:?}", result)
+}

--- a/examples/read_async.rs
+++ b/examples/read_async.rs
@@ -29,12 +29,13 @@ fn main() {
         buffers.push(buf);
     }
 
-    let mut async_pool = AsyncPool::new_bulk(device, endpoint, Duration::from_secs(5), buffers)
-        .expect("Failed to create async pool!");
+    let mut async_pool =
+        AsyncPool::new_bulk(device, endpoint, buffers).expect("Failed to create async pool!");
 
     let mut swap_vec = Vec::with_capacity(BUF_SIZE);
+    let timeout = Duration::from_secs(10);
     loop {
-        let poll_result = async_pool.poll(Duration::from_secs(10), swap_vec);
+        let poll_result = async_pool.poll(timeout, swap_vec);
         match poll_result {
             Ok(data) => {
                 println!("Got data: {:#?}", data);

--- a/src/device_handle/async_api.rs
+++ b/src/device_handle/async_api.rs
@@ -256,6 +256,8 @@ impl<C: UsbContext> AsyncPool<C> {
         }
     }
 }
+unsafe impl<C: UsbContext> Send for AsyncPool<C> {}
+unsafe impl<C: UsbContext> Sync for AsyncPool<C> {}
 
 /// Polls for transfers and executes their callbacks. Will block until the
 /// given timeout, or return immediately if timeout is zero.

--- a/src/device_handle/async_api.rs
+++ b/src/device_handle/async_api.rs
@@ -28,6 +28,8 @@ pub enum AsyncError {
     Errno(&'static str, i32),
     #[error("Transfer was cancelled")]
     Cancelled,
+    #[error("Transfer could not fit into provided buffer with size of {0}")]
+    Overflow(usize),
 }
 
 struct AsyncTransfer<C: UsbContext> {
@@ -260,9 +262,7 @@ impl<C: UsbContext> AsyncPool<C> {
             }
             LIBUSB_TRANSFER_STALL => Err(E::Stall),
             LIBUSB_TRANSFER_NO_DEVICE => Err(E::Disconnected),
-            LIBUSB_TRANSFER_OVERFLOW => {
-                panic!("Device sent more data than expected. Is this even possible when reading?")
-            }
+            LIBUSB_TRANSFER_OVERFLOW => Err(E::Overflow(transfer.buffer.capacity())),
             _ => panic!("Found an unexpected error value for transfer status"),
         };
         match result {

--- a/src/device_handle/async_api.rs
+++ b/src/device_handle/async_api.rs
@@ -1,0 +1,218 @@
+use crate::{DeviceHandle, UsbContext};
+use libusb1_sys as ffi;
+
+use libc::c_void;
+use std::collections::VecDeque;
+use std::convert::{TryFrom, TryInto};
+use std::marker::PhantomPinned;
+use std::pin::Pin;
+use std::ptr::NonNull;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use thiserror::Error;
+
+type CompletedQueue = Arc<Mutex<VecDeque<usize>>>;
+type Transfer<C> = Pin<Box<AsyncTransfer<C>>>;
+
+#[derive(Error, Debug)]
+pub enum AsyncError {
+    #[error("Transfer timed out")]
+    TransferTimeout,
+    #[error("Poll timed out")]
+    PollTimeout,
+    #[error("Transfer is stalled")]
+    Stall,
+    #[error("Device was disconnected")]
+    Disconnected,
+    #[error("Other Error: {0}")]
+    Other(&'static str),
+    #[error("{0}ERRNO: {1}")]
+    Errno(&'static str, i32),
+    #[error("Transfer was cancelled")]
+    Cancelled,
+}
+
+struct AsyncTransfer<C: UsbContext> {
+    ptr: NonNull<ffi::libusb_transfer>,
+    /// The ID of the transfer, as an idx into the transfer pool
+    pool_id: usize,
+    buffer: Vec<u8>,
+    completed_queue: CompletedQueue,
+    device: Arc<DeviceHandle<C>>,
+    // `ptr` holds a pointer to `buffer`, `device`, and `self`, so we must be `!Unpin`
+    _pin: PhantomPinned,
+}
+impl<C: UsbContext> AsyncTransfer<C> {
+    fn new_bulk(
+        pool_id: usize,
+        completed_queue: CompletedQueue,
+        device: Arc<DeviceHandle<C>>,
+        endpoint: u8,
+        buffer: Vec<u8>,
+        timeout: std::time::Duration,
+    ) -> Pin<Box<Self>> {
+        // non-isochronous endpoints (e.g. control, bulk, interrupt) specify a value of 0
+        // This is step 1 of async API
+        let ptr = unsafe { ffi::libusb_alloc_transfer(0) };
+        let ptr = NonNull::new(ptr).expect("Could not allocate transfer!");
+        let timeout = libc::c_uint::try_from(timeout.as_millis())
+            .expect("Duration was too long to fit into a c_uint");
+
+        // Safety: Pinning `result` ensures it doesn't move, but we know that we will
+        // want to access its fields mutably, we just don't want its memory location
+        // changing (or its fields moving!). So routinely we will unsafely interact with
+        // its fields mutably through a shared reference, but this is still sound.
+        let result = Box::pin(Self {
+            ptr,
+            pool_id,
+            buffer,
+            completed_queue,
+            device,
+            _pin: PhantomPinned,
+        });
+        let user_data = std::ptr::addr_of!(*result) as *mut c_void;
+
+        unsafe {
+            // Step 2 of async api
+            ffi::libusb_fill_bulk_transfer(
+                ptr.as_ptr(),
+                result.device.as_raw(),
+                endpoint,
+                result.buffer.as_ptr() as *mut u8,
+                result.buffer.capacity().try_into().unwrap(),
+                Self::transfer_cb,
+                user_data, // We haven't associated with a queue yet, so this is null
+                timeout,
+            )
+        };
+        result
+    }
+
+    // We need to invoke our closure using a c-style function, so we store the closure
+    // inside the custom user data field of the transfer struct, and then call the
+    // user provided closure from there.
+    // Step 4 of async API
+    extern "system" fn transfer_cb(transfer: *mut ffi::libusb_transfer) {
+        // Safety: libusb should never make this null, so this is fine
+        let transfer = unsafe { &mut *transfer };
+
+        // sanity
+        debug_assert_eq!(
+            transfer.transfer_type,
+            ffi::constants::LIBUSB_TRANSFER_TYPE_BULK
+        );
+
+        let transfer: *mut AsyncTransfer<C> = transfer.user_data.cast();
+        let transfer = unsafe { &mut *transfer };
+        // Mark transfer as completed
+        transfer
+            .completed_queue
+            .lock()
+            .unwrap()
+            .push_back(transfer.pool_id);
+    }
+
+    fn submit(self: &mut Transfer<C>) -> Result<(), AsyncError> {
+        todo!()
+    }
+}
+// TODO: Figure out how to destroy transfers
+
+/// Represents a pool of asynchronous transfers, that can be polled to completion
+pub struct AsyncPool<C: UsbContext> {
+    /// Contains the pool of AsyncTransfers
+    pool: Vec<Transfer<C>>,
+    /// Contains the idxs of transfers in the `pool` that have completed
+    completed: CompletedQueue,
+    device: Arc<DeviceHandle<C>>, // TODO: We hold refs to this, do we need it to be pinned?
+}
+impl<C: UsbContext> AsyncPool<C> {
+    pub fn new_bulk(
+        device: DeviceHandle<C>,
+        endpoint: u8,
+        read_timeout: Duration,
+        buffers: impl IntoIterator<Item = Vec<u8>>,
+    ) -> Result<Self, AsyncError> {
+        let buffers = buffers.into_iter();
+        let mut pool = Vec::with_capacity(buffers.size_hint().0);
+        let completed = Arc::new(Mutex::new(VecDeque::with_capacity(buffers.size_hint().0)));
+        let device = Arc::new(device);
+
+        for (id, buf) in buffers.into_iter().enumerate() {
+            let mut transfer: Transfer<C> = AsyncTransfer::new_bulk(
+                id,
+                completed.clone(),
+                device.clone(),
+                endpoint,
+                buf,
+                read_timeout,
+            );
+            transfer.submit()?;
+            pool.push(transfer);
+        }
+        Ok(Self {
+            pool,
+            completed,
+            device,
+        })
+    }
+
+    /// Once a transfer is completed, check the c struct for errors, otherwise swap
+    /// buffers
+    fn handle_completed_transfer(
+        transfer: &mut Transfer<C>,
+        new_buf: Vec<u8>,
+    ) -> Result<Vec<u8>, (AsyncError, Vec<u8>)> {
+        todo!()
+    }
+
+    /// Polls for the completion of async transfers. If successful, will swap the buffer
+    /// of the completed transfer with `new_buf`, otherwise returns `(err, new_buf)` so
+    /// that `new_buf` may be repurposed.
+    pub fn poll(
+        &mut self,
+        timeout: Duration,
+        new_buf: Vec<u8>,
+    ) -> Result<Vec<u8>, (AsyncError, Vec<u8>)> {
+        let pop_result = { self.completed.lock().unwrap().pop_front() };
+        if let Some(id) = pop_result {
+            let ref mut transfer = self.pool[id];
+            return Self::handle_completed_transfer(transfer, new_buf);
+        }
+        // No completed transfers, so poll for some new ones
+        poll_transfers(self.device.context(), timeout);
+        let pop_result = { self.completed.lock().unwrap().pop_front() };
+        if let Some(id) = pop_result {
+            let ref mut transfer = self.pool[id];
+            Self::handle_completed_transfer(transfer, new_buf)
+        } else {
+            Err((AsyncError::PollTimeout, new_buf))
+        }
+    }
+}
+
+/// Polls for transfers and executes their callbacks. Will block until the
+/// given timeout, or return immediately if timeout is zero.
+fn poll_transfers(ctx: &impl UsbContext, timeout: Duration) {
+    let timeval = libc::timeval {
+        tv_sec: timeout.as_secs().try_into().unwrap(),
+        tv_usec: timeout.subsec_millis().try_into().unwrap(),
+    };
+    unsafe {
+        let errno = ffi::libusb_handle_events_timeout_completed(
+            ctx.as_raw(),
+            std::ptr::addr_of!(timeval),
+            std::ptr::null_mut(),
+        );
+        use ffi::constants::*;
+        match errno {
+            0 => (),
+            LIBUSB_ERROR_INVALID_PARAM => panic!("Provided timeout was unexpectedly invalid"),
+            _ => panic!(
+                "Error when polling transfers. ERRNO: {}, Message: {}",
+                errno,
+                std::ffi::CStr::from_ptr(ffi::libusb_strerror(errno)).to_string_lossy()
+            ),
+        }
+    }
+}

--- a/src/device_handle/mod.rs
+++ b/src/device_handle/mod.rs
@@ -1,3 +1,5 @@
+pub mod async_api;
+
 use std::{mem, ptr::NonNull, time::Duration, u8};
 
 use libc::{c_int, c_uchar, c_uint};

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -102,7 +102,12 @@ impl<'a, T: UsbContext> Iterator for Devices<'a, T> {
             let device = self.devices[self.index];
 
             self.index += 1;
-            Some(unsafe { device::Device::from_libusb(self.context.clone(), std::ptr::NonNull::new_unchecked(device)) })
+            Some(unsafe {
+                device::Device::from_libusb(
+                    self.context.clone(),
+                    std::ptr::NonNull::new_unchecked(device),
+                )
+            })
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub use crate::{
     context::{Context, GlobalContext, Hotplug, LogLevel, Registration, UsbContext},
     device::Device,
     device_descriptor::DeviceDescriptor,
+    device_handle::async_api::AsyncPool,
     device_handle::DeviceHandle,
     device_list::{DeviceList, Devices},
     endpoint_descriptor::EndpointDescriptor,
@@ -106,6 +107,11 @@ pub fn open_device_with_vid_pid(
     if handle.is_null() {
         None
     } else {
-        Some(unsafe { DeviceHandle::from_libusb(GlobalContext::default(), std::ptr::NonNull::new_unchecked(handle)) })
+        Some(unsafe {
+            DeviceHandle::from_libusb(
+                GlobalContext::default(),
+                std::ptr::NonNull::new_unchecked(handle),
+            )
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::{
     context::{Context, GlobalContext, Hotplug, LogLevel, Registration, UsbContext},
     device::Device,
     device_descriptor::DeviceDescriptor,
-    device_handle::async_api::AsyncPool,
+    device_handle::async_api::{AsyncError, AsyncPool},
     device_handle::DeviceHandle,
     device_list::{DeviceList, Devices},
     endpoint_descriptor::EndpointDescriptor,


### PR DESCRIPTION
This consolidates #64 and the ideas put forth in #62 to provide a pool-like api for async bulk reads. The implementation is marked as a draft because it is not complete.
