### PR TITLE
Expose the hotplug enumerate flag

### DIFF
--- a/examples/hotplug.rs
+++ b/examples/hotplug.rs
@@ -16,12 +16,17 @@ impl<T: UsbContext> rusb::Hotplug<T> for HotPlugHandler {
 fn main() -> rusb::Result<()> {
     if rusb::has_hotplug() {
         let context = Context::new()?;
-        let mut reg =
-            Some(context.register_callback(None, None, None, Box::new(HotPlugHandler {}))?);
+        let mut reg = Some(context.hotplug_register_callback(
+            None,
+            None,
+            None,
+            true,
+            Box::new(HotPlugHandler {}),
+        )?);
         loop {
             context.handle_events(None).unwrap();
             if let Some(reg) = reg.take() {
-                context.unregister_callback(reg);
+                context.hotplug_unregister_callback(reg);
             }
         }
     } else {

--- a/src/context.rs
+++ b/src/context.rs
@@ -105,7 +105,18 @@ pub trait UsbContext: Clone + Sized + Send + Sync {
         }
     }
 
-    fn register_callback(
+    /// Register a callback to be called on hotplug events. The callback's
+    /// [Hotplug::device_arrived] method is called when a new device is added to
+    /// the bus, and [Hotplug::device_left] is called when it is removed.
+    ///
+    /// Devices can optionally be filtered by vendor ([vendor_id]) and device id
+    /// ([device_id]). If [enumerate] is `true`, then devices that are already
+    /// connected will cause your callback's `device_arrived()` method to be
+    /// called for them.
+    ///
+    /// The callback will remain registered until the returned [Registration] is
+    /// dropped, which can be done explicitly with [hotplug_unregister_callback].
+    fn hotplug_register_callback(
         &self,
         vendor_id: Option<u16>,
         product_id: Option<u16>,
@@ -154,7 +165,9 @@ pub trait UsbContext: Clone + Sized + Send + Sync {
         }
     }
 
-    fn unregister_callback(&self, _reg: Registration<Self>) {}
+    /// Unregisters the callback corresponding to the given registration. The
+    /// same thing can be achieved by dropping the registration.
+    fn hotplug_unregister_callback(&self, _reg: Registration<Self>) {}
 
     fn handle_events(&self, timeout: Option<Duration>) -> crate::Result<()> {
         let n = unsafe {

--- a/src/context.rs
+++ b/src/context.rs
@@ -116,6 +116,7 @@ pub trait UsbContext: Clone + Sized + Send + Sync {
     ///
     /// The callback will remain registered until the returned [Registration] is
     /// dropped, which can be done explicitly with [hotplug_unregister_callback].
+    #[must_use = "USB hotplug callbacks will be deregistered if the registration is dropped"]
     fn hotplug_register_callback(
         &self,
         vendor_id: Option<u16>,


### PR DESCRIPTION
This exposes the hotplug enumerate flag as a `bool` argument to `register_callback()`.  Since this is technically an API-breaking change, I thought I might as well break it more and rename the functions to match the ones in `libusb` (I, personally, had trouble finding them in the docs because they did not have "hotplug" in the name). If you're not a fan of that, that's fine, I'll put it back. I also added some documentation.

One more thing — a thing that tripped me up was not realising that the callback is unregistered when the returned `Registration` is dropped. I added this to the docs, but do you think it would be worth adding a `must_use` attribute to the return value of the register function?