### PR TITLE
Async transfer API added

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = ["libusb1-sys"]
 [dependencies]
 libusb1-sys = { path = "libusb1-sys", version = "0.5.0" }
 libc = "0.2"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 regex = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use crate::{
     },
     language::{Language, PrimaryLanguage, SubLanguage},
     options::UsbOption,
+    transfer::{Transfer, TransferCallbackFunction, TransferStatus},
     version::{version, LibraryVersion},
 };
 
@@ -35,6 +36,7 @@ mod context;
 mod device;
 mod device_handle;
 mod device_list;
+mod transfer;
 
 mod config_descriptor;
 mod device_descriptor;

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1,0 +1,148 @@
+mod shared_state;
+mod unhandled_transfer;
+
+use self::{shared_state::OperationStatus, unhandled_transfer::UnhandledTransfer};
+use std::marker::PhantomData;
+
+use crate::{
+    context::Context,
+    device_handle::DeviceHandle,
+    error::{Error, Result},
+};
+
+#[derive(Clone)]
+pub enum TransferStatus {
+    Completed,
+    Error,
+    Timeout,
+    Cancelled,
+    Stall,
+    NoDevice,
+    Overflow,
+    Unknown,
+}
+
+impl TransferStatus {
+    pub fn to_libusb_result(&self) -> Result<()> {
+        match self {
+            Self::Completed => Ok(()),
+            Self::Timeout => Err(Error::Timeout),
+            Self::Stall => Err(Error::Pipe),
+            Self::NoDevice => Err(Error::NoDevice),
+            Self::Overflow => Err(Error::Overflow),
+            Self::Error | Self::Cancelled => Err(Error::Io),
+            _ => Err(Error::Other),
+        }
+    }
+}
+
+impl TransferStatus {
+    fn from_libusb(code: libc::c_int) -> Self {
+        match code {
+            0 => TransferStatus::Completed,
+            1 => TransferStatus::Error,
+            2 => TransferStatus::Timeout,
+            3 => TransferStatus::Cancelled,
+            4 => TransferStatus::Stall,
+            5 => TransferStatus::NoDevice,
+            6 => TransferStatus::Overflow,
+            _ => TransferStatus::Unknown,
+        }
+    }
+}
+
+pub type TransferCallbackFunction = Option<Box<dyn FnMut(TransferStatus, Vec<u8>)>>;
+
+pub struct Transfer<'a> {
+    unhandled_transfer: *mut UnhandledTransfer,
+    _device_handle: PhantomData<&'a DeviceHandle<Context>>,
+}
+
+impl<'a> Drop for Transfer<'a> {
+    fn drop(&mut self) {
+        let mut state = unsafe { (*self.unhandled_transfer).state.lock().unwrap() };
+        match state.status {
+            OperationStatus::Busy => {
+                state.is_transfer_dropped = true;
+            }
+            OperationStatus::Completed => {
+                UnhandledTransfer::drop(state.handle);
+                unsafe { Box::from_raw(self.unhandled_transfer) };
+            }
+        }
+    }
+}
+
+impl<'a> Transfer<'a> {
+    pub fn new(device_handle: &'a mut DeviceHandle<Context>, iso_packets: i32) -> Result<Self> {
+        let unhandled_transfer = UnhandledTransfer::new(device_handle, iso_packets)?;
+        let transfer = Self {
+            unhandled_transfer,
+            _device_handle: PhantomData,
+        };
+
+        Ok(transfer)
+    }
+
+    pub fn set_endpoint(&mut self, endpoint: u8) -> Result<()> {
+        unsafe {
+            (*(*self.unhandled_transfer).handle).endpoint = endpoint;
+        };
+        Ok(())
+    }
+
+    pub fn set_transfer_type(&mut self, transfer_type: u8) -> Result<()> {
+        unsafe {
+            (*(*self.unhandled_transfer).handle).transfer_type = transfer_type;
+        };
+        Ok(())
+    }
+
+    pub fn set_status(&mut self, status: i32) -> Result<()> {
+        unsafe {
+            (*(*self.unhandled_transfer).handle).status = status;
+        };
+        Ok(())
+    }
+
+    pub fn set_timeout(&mut self, timeout: u32) -> Result<()> {
+        unsafe {
+            (*(*self.unhandled_transfer).handle).timeout = timeout;
+        };
+        Ok(())
+    }
+
+    pub fn set_callback(&mut self, callback: TransferCallbackFunction) -> Result<()> {
+        let mut state = unsafe { (*self.unhandled_transfer).state.lock().unwrap() };
+        state.callback = callback;
+        Ok(())
+    }
+
+    pub fn submit_transfer(
+        &mut self,
+        data: &[u8],
+        bm_request_type: u8,
+        b_request: u8,
+        w_value: u16,
+        w_index: u16,
+    ) -> Result<()> {
+        let mut unhandled_transfer = unsafe { Box::from_raw(self.unhandled_transfer) };
+        let result =
+            unhandled_transfer.submit_transfer(data, bm_request_type, b_request, w_value, w_index);
+
+        Box::into_raw(unhandled_transfer);
+        result?;
+
+        Ok(())
+    }
+
+    pub fn cancel_transfer(&mut self) -> Result<()> {
+        let mut unhandled_transfer = unsafe { Box::from_raw(self.unhandled_transfer) };
+        let result = unhandled_transfer.cancel_transfer();
+
+        Box::into_raw(unhandled_transfer);
+        result?;
+
+        Ok(())
+    }
+}

--- a/src/transfer/shared_state.rs
+++ b/src/transfer/shared_state.rs
@@ -1,0 +1,27 @@
+use super::TransferCallbackFunction;
+use libusb1_sys::*;
+use std::sync::{Arc, Mutex};
+
+pub enum OperationStatus {
+    Busy,
+    Completed,
+}
+
+pub struct SharedState {
+    pub handle: *mut libusb_transfer,
+    pub callback: TransferCallbackFunction,
+    pub status: OperationStatus,
+    pub is_transfer_dropped: bool,
+}
+pub type SharedStatePtr = Arc<Mutex<SharedState>>;
+
+impl SharedState {
+    pub fn new(handle: *mut libusb_transfer) -> Self {
+        Self {
+            handle,
+            callback: None,
+            status: OperationStatus::Completed,
+            is_transfer_dropped: false,
+        }
+    }
+}

--- a/src/transfer/unhandled_transfer.rs
+++ b/src/transfer/unhandled_transfer.rs
@@ -1,0 +1,173 @@
+mod async_awakener;
+
+use self::async_awakener::AsyncAwakener;
+
+use libusb1_sys::constants::*;
+use libusb1_sys::*;
+
+use std::sync::{Arc, Mutex};
+
+use super::{
+    shared_state::{SharedState, SharedStatePtr},
+    OperationStatus, TransferStatus,
+};
+use crate::{
+    context::Context,
+    device_handle::DeviceHandle,
+    error::{Error, Result},
+    UsbContext,
+};
+
+pub struct UnhandledTransfer {
+    pub handle: *mut libusb_transfer,
+    pub state: SharedStatePtr,
+    _awakener: AsyncAwakener,
+    data: Vec<u8>,
+}
+
+impl UnhandledTransfer {
+    pub fn new(device_handle: &mut DeviceHandle<Context>, iso_packets: i32) -> Result<*mut Self> {
+        let handle = Self::allocate_transfer_handle(iso_packets)?;
+
+        unsafe {
+            (*handle).dev_handle = device_handle.as_raw();
+            (*handle).callback = libusb_transfer_callback_function;
+        }
+
+        let local_context = device_handle.context().clone();
+        let awakener = AsyncAwakener::spawn(move || unsafe {
+            libusb_handle_events_completed(local_context.as_raw(), std::ptr::null_mut());
+        });
+
+        let transfer = Box::new(Self {
+            handle,
+            state: Arc::new(Mutex::new(SharedState::new(handle))),
+            _awakener: awakener,
+            data: vec![],
+        });
+        let transfer = Box::into_raw(transfer);
+
+        unsafe {
+            (*handle).user_data =
+                std::mem::transmute::<*mut UnhandledTransfer, *mut libc::c_void>(transfer);
+        }
+
+        Ok(transfer)
+    }
+
+    pub fn drop(handle: *mut libusb_transfer) {
+        unsafe {
+            libusb_cancel_transfer(handle);
+            libusb_free_transfer(handle);
+        }
+    }
+
+    pub fn submit_transfer(
+        &mut self,
+        data: &[u8],
+        bm_request_type: u8,
+        b_request: u8,
+        w_value: u16,
+        w_index: u16,
+    ) -> Result<()> {
+        let mut state = match self.state.lock() {
+            Err(_) => return Err(Error::Other),
+            Ok(state) => state,
+        };
+
+        if let OperationStatus::Busy = state.status {
+            return Err(Error::Busy);
+        }
+        state.status = OperationStatus::Busy;
+
+        let setup_packet = Self::create_setup_packet(
+            bm_request_type,
+            b_request,
+            w_value,
+            w_index,
+            data.len() as u16,
+        )?;
+
+        self.data = setup_packet
+            .into_iter()
+            .chain(data.iter().copied())
+            .collect::<Vec<u8>>();
+
+        unsafe {
+            (*self.handle).buffer = self.data.as_mut_ptr();
+            (*self.handle).length = self.data.len() as i32;
+        }
+
+        try_unsafe!(libusb_submit_transfer(self.handle));
+
+        Ok(())
+    }
+
+    pub fn cancel_transfer(&mut self) -> Result<()> {
+        try_unsafe!(libusb_cancel_transfer(self.handle));
+        Ok(())
+    }
+
+    fn allocate_transfer_handle(iso_packets: i32) -> Result<*mut libusb_transfer> {
+        let transfer_handle = unsafe { libusb_alloc_transfer(iso_packets) };
+        if transfer_handle == std::ptr::null_mut() {
+            return Err(Error::NoMem);
+        }
+
+        Ok(transfer_handle)
+    }
+
+    fn create_setup_packet(
+        bm_request_type: u8,
+        b_request: u8,
+        w_value: u16,
+        w_index: u16,
+        data_size: u16,
+    ) -> Result<Vec<u8>> {
+        // Actual at the time of version 1.0.23
+        static_assertions::const_assert!(LIBUSB_CONTROL_SETUP_SIZE == 8);
+
+        let mut setup_packet = vec![bm_request_type, b_request];
+        setup_packet.extend(w_value.to_le_bytes().iter());
+        setup_packet.extend(w_index.to_le_bytes().iter());
+        setup_packet.extend(data_size.to_le_bytes().iter());
+
+        Ok(setup_packet)
+    }
+}
+
+extern "system" fn libusb_transfer_callback_function(transfer_handle: *mut libusb_transfer) {
+    let transfer = unsafe {
+        Box::from_raw(std::mem::transmute::<
+            *mut libc::c_void,
+            *mut UnhandledTransfer,
+        >((*transfer_handle).user_data))
+    };
+
+    let state = transfer.state.clone();
+    let mut state = state.lock().unwrap();
+
+    if state.is_transfer_dropped {
+        UnhandledTransfer::drop(state.handle);
+    } else {
+        state.status = OperationStatus::Completed;
+
+        let status = unsafe { (*state.handle).status };
+        if let Some(ref mut callback) = state.callback {
+            let status = TransferStatus::from_libusb(status);
+            let actual_length = unsafe { (*transfer_handle).actual_length };
+            callback(
+                status,
+                transfer
+                    .data
+                    .iter()
+                    .copied()
+                    .take(actual_length as usize)
+                    .collect(),
+            );
+        }
+
+        // forget about transfer
+        Box::into_raw(transfer);
+    }
+}

--- a/src/transfer/unhandled_transfer/async_awakener.rs
+++ b/src/transfer/unhandled_transfer/async_awakener.rs
@@ -1,0 +1,31 @@
+use std::{
+    sync::{Arc, Mutex},
+    thread,
+};
+
+type Signal = Arc<Mutex<bool>>;
+
+pub struct AsyncAwakener {
+    signal: Signal,
+}
+
+impl Drop for AsyncAwakener {
+    fn drop(&mut self) {
+        *self.signal.lock().unwrap() = false;
+    }
+}
+
+impl AsyncAwakener {
+    pub fn spawn<F: 'static + Send + FnMut()>(mut func: F) -> Self {
+        let signal = Arc::new(Mutex::new(true));
+
+        let thread_signal = signal.clone();
+        thread::spawn(move || {
+            while *thread_signal.lock().unwrap() {
+                func();
+            }
+        });
+
+        Self { signal }
+    }
+}


### PR DESCRIPTION
Good day.

This pr suggests some API updates to support async transfers.

Async transfer usage:
```
let mut transfer = rusb::Transfer::<'a>::new(&device_handle, 0)?;
transfer.set_transfer_type(rusb::constants::LIBUSB_TRANSFER_TYPE_CONTROL)?;
transfer.set_timeout(1000)?;
transfer.set_endpoint(0)?;

transfer.set_callback(Some(Box::new(move |status, data| {
    // process data
})))?;

transfer.submit_transfer(
    [0u8;10], // data
    0, bm_request_type,
    0, b_request,
    0, w_value,
    0, w_index,
)?;
```

You can take this changes as a base for your own API or just merge it as is.