### PR TITLE
Allow null function pointers for libusb_set_log_cb

### DIFF
--- a/libusb1-sys/CHANGELOG.md
+++ b/libusb1-sys/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changes
+
+
+## Unreleased
+* Allow null function pointers for libusb_set_log_cb() [#74]
+
+[#74]: https://github.com/a1ien/rusb/pull/74

--- a/libusb1-sys/Cargo.toml
+++ b/libusb1-sys/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["David Cuddeback <david.cuddeback@gmail.com>",
             "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "FFI bindings for libusb."
 license = "MIT"
-homepage = "https://github.com/a1ien/libusb1-sys"
-repository = "https://github.com/a1ien/libusb1-sys.git"
+homepage = "https://github.com/a1ien/rusb"
+repository = "https://github.com/a1ien/rusb.git"
 readme = "README.md"
 keywords = ["usb", "libusb", "hardware", "bindings"]
 edition = "2018"
@@ -23,6 +23,7 @@ include = [
     "Cargo.toml",
     "LICENSE",
     "README.md",
+    "CHANGELOG.md",
     "COPYING",
     "AUTHORS",
 ]

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -230,7 +230,7 @@ extern "system" {
     pub fn libusb_init(context: *mut *mut libusb_context) -> c_int;
     pub fn libusb_exit(context: *mut libusb_context);
     pub fn libusb_set_debug(context: *mut libusb_context, level: c_int);
-    pub fn libusb_set_log_cb(context: *mut libusb_context, cb: libusb_log_cb, mode: c_int);
+    pub fn libusb_set_log_cb(context: *mut libusb_context, cb: Option<libusb_log_cb>, mode: c_int);
 
     pub fn libusb_get_device_list(
         context: *mut libusb_context,


### PR DESCRIPTION
[libusb_set_log_cb](https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html#ga2efb66b8f16ffb0851f3907794c06e20) cb: pointer to the callback function, or NULL to stop log messages redirection