### PR TITLE
Log callback API added

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ vendored = [ "libusb1-sys/vendored" ]
 members = ["libusb1-sys"]
 
 [dependencies]
+lazy_static = "1.4.0"
 libusb1-sys = { path = "libusb1-sys", version = "0.5.0" }
 libc = "0.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,9 @@ pub use libusb1_sys::constants;
 
 pub use crate::{
     config_descriptor::{ConfigDescriptor, Interfaces},
-    context::{Context, GlobalContext, Hotplug, LogLevel, Registration, UsbContext},
+    context::{
+        Context, GlobalContext, Hotplug, LogCallbackMode, LogLevel, Registration, UsbContext,
+    },
     device::Device,
     device_descriptor::DeviceDescriptor,
     device_handle::DeviceHandle,


### PR DESCRIPTION
Good day.

This pr suggests some API updates to support log callbacks.

Log callback setup:
```
let mut context = rusb::Context::new()?;
context.set_log_level(rusb::LogLevel::Info);

let cb = Box::new(move |level: rusb::LogLevel, text: String| {
    println!(log_file, "[{:#?}] {}", level, text).ok();
});

context.set_log_callback(cb, rusb::LogCallbackMode::Context);
```

You can take this changes as a base for your own API or just merge it as is.