### PR TITLE
Fix cargo doc warning

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -17,7 +17,7 @@ impl Language {
     /// Returns the language's 16-bit `LANGID`.
     ///
     /// Each language's `LANGID` is defined by the USB forum
-    /// (http://www.usb.org/developers/docs/USB_LANGIDs.pdf).
+    /// <http://www.usb.org/developers/docs/USB_LANGIDs.pdf>.
     pub fn lang_id(self) -> u16 {
         self.raw
     }


### PR DESCRIPTION
Fixes:
warning: this URL is not a hyperlink