### PR TITLE
Do not require UsbContext: Sized

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -70,7 +70,7 @@ impl<T: UsbContext> Drop for Registration<T> {
     }
 }
 
-pub trait UsbContext: Clone + Sized + Send + Sync {
+pub trait UsbContext: Clone + Send + Sync {
     /// Get the raw libusb_context pointer, for advanced use in unsafe code.
     fn as_raw(&self) -> *mut libusb_context;
 


### PR DESCRIPTION
This prevent using a context as a trait object.

From E0038:
Generally, `Self: Sized` is used to indicate that the trait should not be used
as a trait object. If the trait comes from your own crate, consider removing
this restriction.