### PR TITLE
Fix building of recent libusb on macOS

### DIFF
--- a/libusb1-sys/build.rs
+++ b/libusb1-sys/build.rs
@@ -103,9 +103,11 @@ fn make_source() {
 
     if std::env::var("CARGO_CFG_TARGET_OS") == Ok("macos".into()) {
         base_config.define("OS_DARWIN", Some("1"));
+        base_config.define("TARGET_OS_OSX", Some("1"));
         base_config.file(libusb_source.join("libusb/os/darwin_usb.c"));
         link_framework("CoreFoundation");
         link_framework("IOKit");
+        link_framework("Security");
         link("objc", false);
     }
 


### PR DESCRIPTION
Previously, building a recent version of libusb on macOS as a vendored copy would fail with a linker error. Specifically, commit

[6a902c3b207a017cd699ac8bb6659abf32eb0c99 of libusb](https://github.com/libusb/libusb/commit/6a902c3b207a017cd699ac8bb6659abf32eb0c99)

requires that the environment variable `TARGET_OS_OSX` is set on macOS targets and needs to link against Security.framework. I have verified that these changes allow the build to complete successfully on both macOS 10.13 High Sierra and macOS 11 Big Sur.

If one uses the version of libusb that you include as a submodule, you do not yet run into this issue, however it occurs if that version is swapped out with a never version. As soon as libusb releases a new version and you update, this change will also be necessary. However, I can't find a reason not to change this now for future compatibility.