### PR TITLE
Ignore vendored feature on FreeBSD

### DIFF
--- a/libusb1-sys/build.rs
+++ b/libusb1-sys/build.rs
@@ -178,7 +178,9 @@ fn main() {
         .map(|s| s.contains("crt-static"))
         .unwrap_or_default();
 
-    if cfg!(feature = "vendored") || !find_libusb_pkg(statik) {
+    let is_freebsd = std::env::var("CARGO_CFG_TARGET_OS") == Ok("freebsd".into());
+
+    if (!is_freebsd && cfg!(feature = "vendored")) || !find_libusb_pkg(statik) {
         make_source();
     }
 }


### PR DESCRIPTION
As libusb is include in the FreeBSD base system[1], we should just use the
os provided version.

This'll also fix a compilation error, the pressences of the libudev devd
compatibility interface[2] cause linux header to be included.

[1]: https://cgit.freebsd.org/src/tree/lib/libusb
[2]: https://www.freshports.org/devel/libudev-devd