### PR TITLE
Allow external libusb

### DIFF
--- a/libusb1-sys/build.rs
+++ b/libusb1-sys/build.rs
@@ -176,6 +176,19 @@ fn make_source() {
 }
 
 fn main() {
+    if std::env::var("EXTERNAL_LIBUSB") == Ok("1".into()) {
+        let include_dir = std::env::var("EXTERNAL_LIBUSB_INCLUDE")
+            .expect("EXTERNAL_LIBUSB_INCLUDE is required with EXTERNAL_LIBUSB set");
+
+        let lib_dir = std::env::var("EXTERNAL_LIBUSB_LIB")
+            .expect("EXTERNAL_LIBUSB_LIB is required with EXTERNAL_LIBUSB set");
+
+        println!("cargo:include={}/libusb.h", include_dir);
+        println!("cargo:rustc-link-search=native={}", lib_dir);
+        println!("cargo:rustc-link-lib=dylib=usb-1.0");
+        return;
+    }
+
     let statik = std::env::var("CARGO_CFG_TARGET_FEATURE")
         .map(|s| s.contains("crt-static"))
         .unwrap_or_default();


### PR DESCRIPTION
I have a embedded platform with a custom libusb that i would like to use with rusb when cross compiling. The easiest way i came up with is to allow the build system to specify a path to my libusb.

Do you have any other ideas on how to solve this problem or would you like to accept something like this solution?

Cheer!