### PR TITLE
Rename compiled library when vendored libusb is used

### DIFF
--- a/libusb1-sys/build.rs
+++ b/libusb1-sys/build.rs
@@ -168,7 +168,7 @@ fn make_source() {
     base_config.file(libusb_source.join("libusb/strerror.c"));
     base_config.file(libusb_source.join("libusb/sync.c"));
 
-    base_config.compile("libusb.a");
+    base_config.compile("usb-vendored");
     println!("cargo:version_number={}", VERSION);
 }
 


### PR DESCRIPTION
This should fix #117.

The name doesn't really matter, since static linking is used. By changing the name from `libusb.a`, a conflict with the system package is avoided.