### PR TITLE
context: create rusb `Context` from existing `libusb_context`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -233,13 +233,7 @@ impl Context {
 
         try_unsafe!(libusb_init(context.as_mut_ptr()));
 
-        Ok(Context {
-            context: unsafe {
-                Arc::new(ContextInner {
-                    inner: ptr::NonNull::new_unchecked(context.assume_init()),
-                })
-            },
-        })
+        Ok(unsafe { Self::from_raw(context.assume_init()) })
     }
 
     /// Creates a new `libusb` context and sets runtime options.
@@ -254,14 +248,15 @@ impl Context {
     }
 
     /// Creates rusb Context from existing libusb context.
-    // SAFETY: the caller must guarantee that libusb_context is created properly.
-    pub fn from_raw(raw: *mut libusb_context) -> Self {
+    /// Note: This transfers ownership of the context to Rust.
+    /// # Safety
+    /// This is unsafe because it does not check if the context is valid,
+    /// so the caller must guarantee that libusb_context is created properly.
+    pub unsafe fn from_raw(raw: *mut libusb_context) -> Self {
         Context {
-            context: unsafe {
-                Arc::new(ContextInner {
-                    inner: ptr::NonNull::new_unchecked(raw),
-                })
-            },
+            context: Arc::new(ContextInner {
+                inner: ptr::NonNull::new_unchecked(raw),
+            }),
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -252,6 +252,18 @@ impl Context {
 
         Ok(this)
     }
+
+    /// Creates rusb Context from existing libusb context.
+    // SAFETY: the caller must guarantee that libusb_context is created properly.
+    pub fn from_raw(raw: *mut libusb_context) -> Self {
+        Context {
+            context: unsafe {
+                Arc::new(ContextInner {
+                    inner: ptr::NonNull::new_unchecked(raw),
+                })
+            },
+        }
+    }
 }
 
 /// Library logging levels.


### PR DESCRIPTION
Allows to create context separately, initialize libusb, and then initialize `Context` with it.

The ability to create Context from existing context is necessary to use rusb with Android because on Android `libusb_init` should be called with special option that prevents device enumeration. More on it [here](https://github.com/libusb/libusb/blob/master/android/README).