### PR TITLE
Fix stack use after scope in tests

### DIFF
--- a/src/config_descriptor.rs
+++ b/src/config_descriptor.rs
@@ -137,7 +137,8 @@ mod test {
     // as `$config` should be stack-allocated to prevent memory leaks in the test suite.
     macro_rules! with_config {
         ($name:ident : $config:expr => $body:block) => {{
-            let $name = ManuallyDrop::new(unsafe { super::from_libusb(&$config) });
+            let config = $config;
+            let $name = ManuallyDrop::new(unsafe { super::from_libusb(&config) });
             $body;
         }};
     }


### PR DESCRIPTION
The config in these tests was freed when the call to from_libusb returns,
thus all access through the pointer afterwards would be invalid.