### PR TITLE
fields.rs: Make request_type function a const fn

### DIFF
--- a/src/fields.rs
+++ b/src/fields.rs
@@ -206,7 +206,11 @@ impl std::fmt::Display for Version {
 ///
 /// rusb::request_type(Direction::In, RequestType::Standard, Recipient::Device);
 /// ```
-pub fn request_type(direction: Direction, request_type: RequestType, recipient: Recipient) -> u8 {
+pub const fn request_type(
+    direction: Direction,
+    request_type: RequestType,
+    recipient: Recipient,
+) -> u8 {
     let mut value: u8 = match direction {
         Direction::Out => LIBUSB_ENDPOINT_OUT,
         Direction::In => LIBUSB_ENDPOINT_IN,


### PR DESCRIPTION
Make request_type function in fields.rs a const fn so that it can used
to create const global variables.

Test: The following code now compiles

```
const CTRL_OUT: u8 = request_type(
    rusb::Direction::Out,
    rusb::RequestType::Vendor,
    rusb::Recipient::Device,
);
```