### PR TITLE
Increase endpoint descriptor's lifetime

### DIFF
--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -90,7 +90,7 @@ impl<'a> InterfaceDescriptor<'a> {
     }
 
     /// Returns an iterator over the interface's endpoint descriptors.
-    pub fn endpoint_descriptors(&self) -> EndpointDescriptors {
+    pub fn endpoint_descriptors(&self) -> EndpointDescriptors<'a> {
         let endpoints = unsafe {
             slice::from_raw_parts(
                 self.descriptor.endpoint,


### PR DESCRIPTION
From my understanding, all state derived from a `ConfigDescriptor` has a lifetime associated to that `ConfigDescriptor`. So, it's safe for the `EndpointDescriptor` to adopt the `ConfigDescriptor`'s lifetime through the `InterfaceDescriptor`.

The new test shows us that the lifetimes are now all equal. This test wouldn't compile without the signature change.