### PR TITLE
Add a function to disable device discovery

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 pub use libusb1_sys as ffi;
 pub use libusb1_sys::constants;
 
+#[cfg(unix)]
+pub use crate::options::disable_device_discovery;
 pub use crate::{
     config_descriptor::{ConfigDescriptor, Interfaces},
     context::{Context, GlobalContext, LogLevel, UsbContext},

--- a/src/options.rs
+++ b/src/options.rs
@@ -37,3 +37,21 @@ enum OptionInner {
     #[cfg_attr(not(windows), allow(dead_code))] // only constructed on Windows
     UseUsbdk,
 }
+
+/// Disable device scanning in `libusb` init.
+///
+/// Hotplug functionality will also be deactivated.
+///
+/// This is a Linux only option and it must be set before any [`Context`]
+/// creation.
+///
+/// The option is useful in combination with [`Context::open_device_with_fd()`],
+/// which can access a device directly without prior device scanning.
+#[cfg(unix)]
+pub fn disable_device_discovery() -> crate::Result<()> {
+    try_unsafe!(libusb1_sys::libusb_set_option(
+        std::ptr::null_mut(),
+        LIBUSB_OPTION_NO_DEVICE_DISCOVERY
+    ));
+    Ok(())
+}


### PR DESCRIPTION
Hello !

This commit adds a convenient function to disable scanning devices in **libusb_init()**, see https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html#gga07d4ec54cf575d672ba94c72b3c0de7ca5534030a8299c85555aebfae39161ef7