### PR TITLE
fix: Add missing fields to libusb_bos_descriptor and libusb_bos_dev_capability_descriptor

### DIFF
--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -126,6 +126,7 @@ pub struct libusb_bos_dev_capability_descriptor {
     pub bLength: u8,
     pub bDescriptorType: u8,
     pub bDevCapabilityType: u8,
+    pub dev_capability_data: [u8; 0],
 }
 
 #[allow(non_snake_case)]
@@ -135,6 +136,7 @@ pub struct libusb_bos_descriptor {
     pub bDescriptorType: u8,
     pub wTotalLength: u16,
     pub bNumDeviceCaps: u8,
+    pub dev_capability: [libusb_bos_dev_capability_descriptor; 0],
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION

This fix adds missing fields to these two structs so that they can be used from rust without the size mismatching from the C version.

See:

https://libusb.sourceforge.io/api-1.0/structlibusb__bos__descriptor.html 
https://libusb.sourceforge.io/api-1.0/structlibusb__bos__dev__capability__descriptor.html