### PR TITLE
Add serde support for public enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = ["libusb1-sys"]
 [dependencies]
 libusb1-sys = { path = "libusb1-sys", version = "0.6.0" }
 libc = "0.2"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 regex = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,8 @@
 use std::{fmt, result};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use libusb1_sys::constants::*;
 
 /// A result of a function that may return a `Error`.
@@ -7,6 +10,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 /// Errors returned by the `libusb` library.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Error {
     /// Input/output error.
     Io,

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1,10 +1,14 @@
 use libc::c_int;
 use libusb1_sys::constants::*;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Device speeds. Indicates the speed at which a device is operating.
 /// - [libusb_supported_speed](http://libusb.sourceforge.net/api-1.0/group__libusb__dev.html#ga1454797ecc0de4d084c1619c420014f6)
 /// - [USB release versions](https://en.wikipedia.org/wiki/USB#Release_versions)
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum Speed {
     /// The operating system doesn't know the device speed.
@@ -41,6 +45,7 @@ pub(crate) fn speed_from_libusb(n: c_int) -> Speed {
 
 /// Transfer and endpoint directions.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Direction {
     /// Direction for read (device to host) transfers.
     In,
@@ -51,6 +56,7 @@ pub enum Direction {
 
 /// An endpoint's transfer type.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TransferType {
     /// Control endpoint.
     Control,
@@ -67,6 +73,7 @@ pub enum TransferType {
 
 /// Isochronous synchronization mode.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SyncType {
     /// No synchronisation.
     NoSync,
@@ -83,6 +90,7 @@ pub enum SyncType {
 
 /// Isochronous usage type.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum UsageType {
     /// Data endpoint.
     Data,
@@ -99,6 +107,7 @@ pub enum UsageType {
 
 /// Types of control transfers.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum RequestType {
     /// Requests that are defined by the USB standard.
     Standard,
@@ -115,6 +124,7 @@ pub enum RequestType {
 
 /// Recipients of control transfers.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Recipient {
     /// The recipient is a device.
     Device,
@@ -144,6 +154,7 @@ pub enum Recipient {
 /// The intended use case of `Version` is to extract meaning from the version fields in USB
 /// descriptors, such as `bcdUSB` and `bcdDevice` in device descriptors.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Version(pub u8, pub u8, pub u8);
 
 impl Version {


### PR DESCRIPTION
Ref #81

I have only implemented serialization/deserialization for the public enums for now. The structs largely depended on the types in libusb1-sys, which is nontrivial to serialize due to things like raw pointers and user defined data, and doesn't really make sense to deserialize (AFAIK).

The serialization is hidden behind the `serde` feature flag.