### PR TITLE
Add Device port_string() function

### DIFF
--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -46,11 +46,12 @@ fn list_devices() -> Result<()> {
         };
 
         println!(
-            "Bus {:03} Device {:03} ID {:04x}:{:04x} {}",
+            "Bus {:03} Device {:03} ID {:04x}:{:04x} Port {} {}",
             device.bus_number(),
             device.address(),
             device_desc.vendor_id(),
             device_desc.product_id(),
+            device.port_string().unwrap_or_default(),
             get_speed(device.speed())
         );
         print_device(&device_desc, &mut usb_device);

--- a/src/device.rs
+++ b/src/device.rs
@@ -175,4 +175,30 @@ impl<T: UsbContext> Device<T> {
         };
         Ok(ports[0..ports_number as usize].to_vec())
     }
+
+    /// Gets the a string describing the unique port to which the device is
+    /// attached.
+    ///
+    /// The port string is in the form:
+    /// ```text
+    /// <bus>[-<port>[.<port>[.<port>[...]]]]
+    /// ```
+    ///
+    /// like `4-1.2`. This can be used on any system, but is especially useful
+    /// in Linux as it is compatible with the port designation in the device
+    /// path and system path for USB devices.
+    pub fn port_string(&self) -> crate::Result<String> {
+        let mut s = self.bus_number().to_string();
+        let ports = self.port_numbers()?;
+
+        if !ports.is_empty() {
+            s.push_str(&format!("-{}", ports[0]));
+
+            for port in ports.iter().skip(1) {
+                s.push_str(&format!(".{}", port));
+            }
+        }
+        Ok(s)
+    }
+
 }


### PR DESCRIPTION
This adds a `Device::port_string()` function. The string describes the _unique_ physical port to which a USB device is attached. The format of the string is compatible with the one used by Linux in the form: `<bus>-<port>.<port>...`, like: `4-1.2`.

It is simply a string representation of the bus number and port vector. Although it uses the Linux format, it should work on any OS.

The primary use for the port string is to easily, uniquely identify a device on a given host, particularly when multiple, identical, devices are attached to the host and can not be differentiated in any other way. This happens when two of the same devices are attached with the same VID:PID, but do not have serial numbers or other distinguishing identifiers.

On Linux, it is also directly useful to compare to fields in the devpath/syspath and can be used to find the device in the _syspath_ at `/sys/bus/usb/devices/<port_string>`