### PR TITLE
Implemented Display trait for Speed and conversion to float Mbps

### DIFF
--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -1,6 +1,6 @@
 use rusb::{
     ConfigDescriptor, DeviceDescriptor, DeviceHandle, DeviceList, EndpointDescriptor,
-    InterfaceDescriptor, Language, Result, Speed, UsbContext,
+    InterfaceDescriptor, Language, Result, UsbContext,
 };
 use std::time::Duration;
 
@@ -46,12 +46,13 @@ fn list_devices() -> Result<()> {
         };
 
         println!(
-            "Bus {:03} Device {:03} ID {:04x}:{:04x} {}",
+            "Bus {:03} Device {:03} ID {:04x}:{:04x} Speed {} ({} Mbps)",
             device.bus_number(),
             device.address(),
             device_desc.vendor_id(),
             device_desc.product_id(),
-            get_speed(device.speed())
+            device.speed(),
+            device.speed().as_mbps()
         );
         print_device(&device_desc, &mut usb_device);
 
@@ -246,15 +247,4 @@ fn print_endpoint(endpoint_desc: &EndpointDescriptor) {
         "        bInterval            {:3}",
         endpoint_desc.interval()
     );
-}
-
-fn get_speed(speed: Speed) -> &'static str {
-    match speed {
-        Speed::SuperPlus => "10000 Mbps",
-        Speed::Super => "5000 Mbps",
-        Speed::High => " 480 Mbps",
-        Speed::Full => "  12 Mbps",
-        Speed::Low => " 1.5 Mbps",
-        _ => "(unknown)",
-    }
 }

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1,5 +1,6 @@
 use libc::c_int;
 use libusb1_sys::constants::*;
+use std::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -28,6 +29,28 @@ pub enum Speed {
 
     /// The device is operating at super speed (10 Gbps).
     SuperPlus,
+}
+
+impl Speed {
+    /// Gets the speed in floating point megabits per second.
+    /// If the speed is unknown, it is reported as 0.0
+    pub fn as_mbps(&self) -> f64 {
+        use Speed::*;
+        match *self {
+            Low => 1.5,
+            Full => 12.0,
+            High => 480.0,
+            Super => 5000.0,
+            SuperPlus => 10000.0,
+            _ => 0.0,
+        }
+    }
+}
+
+impl fmt::Display for Speed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", *self)
+    }
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Implemented a conversion of `Speed` to float Mbps - so no additional conversion function would be needed by examples and applications. 

Also implemented a `Display` trait for `Speed`.