### PR TITLE
Single Context type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = ["libusb1-sys"]
 [dependencies]
 libusb1-sys = { path = "libusb1-sys", version = "0.6.0" }
 libc = "0.2"
+once_cell = "1.18"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/examples/hotplug.rs
+++ b/examples/hotplug.rs
@@ -1,13 +1,13 @@
-use rusb::{Context, Device, HotplugBuilder, UsbContext};
+use rusb::{Context, Device, HotplugBuilder};
 
 struct HotPlugHandler;
 
-impl<T: UsbContext> rusb::Hotplug<T> for HotPlugHandler {
-    fn device_arrived(&mut self, device: Device<T>) {
+impl rusb::Hotplug for HotPlugHandler {
+    fn device_arrived(&mut self, device: Device) {
         println!("device arrived {:?}", device);
     }
 
-    fn device_left(&mut self, device: Device<T>) {
+    fn device_left(&mut self, device: Device) {
         println!("device left {:?}", device);
     }
 }
@@ -25,7 +25,7 @@ fn main() -> rusb::Result<()> {
         let mut reg = Some(
             HotplugBuilder::new()
                 .enumerate(true)
-                .register(&context, Box::new(HotPlugHandler {}))?,
+                .register(context.clone(), Box::new(HotPlugHandler {}))?,
         );
 
         loop {

--- a/examples/libusb_info.rs
+++ b/examples/libusb_info.rs
@@ -1,4 +1,3 @@
-
 fn main() {
     let version = rusb::version();
 

--- a/examples/libusb_info.rs
+++ b/examples/libusb_info.rs
@@ -1,4 +1,3 @@
-use rusb::UsbContext;
 
 fn main() {
     let version = rusb::version();

--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -13,7 +13,9 @@ struct UsbDevice {
 }
 
 fn main() {
-    list_devices().unwrap();
+    if let Err(err) = list_devices() {
+        eprintln!("{}", err);
+    }
 }
 
 fn list_devices() -> Result<()> {
@@ -172,10 +174,7 @@ fn print_config(config_desc: &ConfigDescriptor, handle: &mut Option<UsbDevice>) 
     }
 }
 
-fn print_interface(
-    interface_desc: &InterfaceDescriptor,
-    handle: &mut Option<UsbDevice>,
-) {
+fn print_interface(interface_desc: &InterfaceDescriptor, handle: &mut Option<UsbDevice>) {
     println!("    Interface Descriptor:");
     println!(
         "      bInterfaceNumber     {:3}",

--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -1,13 +1,13 @@
 use rusb::{
     ConfigDescriptor, DeviceDescriptor, DeviceHandle, DeviceList, EndpointDescriptor,
-    InterfaceDescriptor, Language, Result, Speed, UsbContext,
+    InterfaceDescriptor, Language, Result, Speed,
 };
 use std::time::Duration;
 
 use usb_ids::{self, FromId};
 
-struct UsbDevice<T: UsbContext> {
-    handle: DeviceHandle<T>,
+struct UsbDevice {
+    handle: DeviceHandle,
     language: Language,
     timeout: Duration,
 }
@@ -78,7 +78,7 @@ fn list_devices() -> Result<()> {
     Ok(())
 }
 
-fn print_device<T: UsbContext>(device_desc: &DeviceDescriptor, handle: &mut Option<UsbDevice<T>>) {
+fn print_device(device_desc: &DeviceDescriptor, handle: &mut Option<UsbDevice>) {
     let vid = device_desc.vendor_id();
     let pid = device_desc.product_id();
 
@@ -145,7 +145,7 @@ fn print_device<T: UsbContext>(device_desc: &DeviceDescriptor, handle: &mut Opti
     );
 }
 
-fn print_config<T: UsbContext>(config_desc: &ConfigDescriptor, handle: &mut Option<UsbDevice<T>>) {
+fn print_config(config_desc: &ConfigDescriptor, handle: &mut Option<UsbDevice>) {
     println!("  Config Descriptor:");
     println!(
         "    bNumInterfaces       {:3}",
@@ -172,9 +172,9 @@ fn print_config<T: UsbContext>(config_desc: &ConfigDescriptor, handle: &mut Opti
     }
 }
 
-fn print_interface<T: UsbContext>(
+fn print_interface(
     interface_desc: &InterfaceDescriptor,
-    handle: &mut Option<UsbDevice<T>>,
+    handle: &mut Option<UsbDevice>,
 ) {
     println!("    Interface Descriptor:");
     println!(

--- a/examples/read_device.rs
+++ b/examples/read_device.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use rusb::{
-    Context, Device, DeviceDescriptor, DeviceHandle, Direction, Result, TransferType, UsbContext,
+    Context, Device, DeviceDescriptor, DeviceHandle, Direction, Result, TransferType,
 };
 
 #[derive(Debug)]
@@ -42,11 +42,11 @@ fn main() {
     }
 }
 
-fn open_device<T: UsbContext>(
-    context: &mut T,
+fn open_device(
+    context: &mut Context,
     vid: u16,
     pid: u16,
-) -> Option<(Device<T>, DeviceDescriptor, DeviceHandle<T>)> {
+) -> Option<(Device, DeviceDescriptor, DeviceHandle)> {
     let devices = match context.devices() {
         Ok(d) => d,
         Err(_) => return None,
@@ -69,10 +69,10 @@ fn open_device<T: UsbContext>(
     None
 }
 
-fn read_device<T: UsbContext>(
-    device: &mut Device<T>,
+fn read_device(
+    device: &mut Device,
     device_desc: &DeviceDescriptor,
-    handle: &mut DeviceHandle<T>,
+    handle: &mut DeviceHandle,
 ) -> Result<()> {
     handle.reset()?;
 
@@ -118,8 +118,8 @@ fn read_device<T: UsbContext>(
     Ok(())
 }
 
-fn find_readable_endpoint<T: UsbContext>(
-    device: &mut Device<T>,
+fn find_readable_endpoint(
+    device: &mut Device,
     device_desc: &DeviceDescriptor,
     transfer_type: TransferType,
 ) -> Option<Endpoint> {
@@ -150,8 +150,8 @@ fn find_readable_endpoint<T: UsbContext>(
     None
 }
 
-fn read_endpoint<T: UsbContext>(
-    handle: &mut DeviceHandle<T>,
+fn read_endpoint(
+    handle: &mut DeviceHandle,
     endpoint: Endpoint,
     transfer_type: TransferType,
 ) {
@@ -198,8 +198,8 @@ fn read_endpoint<T: UsbContext>(
     }
 }
 
-fn configure_endpoint<T: UsbContext>(
-    handle: &mut DeviceHandle<T>,
+fn configure_endpoint(
+    handle: &mut DeviceHandle,
     endpoint: &Endpoint,
 ) -> Result<()> {
     handle.set_active_configuration(endpoint.config)?;

--- a/examples/read_device.rs
+++ b/examples/read_device.rs
@@ -1,8 +1,6 @@
 use std::time::Duration;
 
-use rusb::{
-    Context, Device, DeviceDescriptor, DeviceHandle, Direction, Result, TransferType,
-};
+use rusb::{Context, Device, DeviceDescriptor, DeviceHandle, Direction, Result, TransferType};
 
 #[derive(Debug)]
 struct Endpoint {
@@ -150,11 +148,7 @@ fn find_readable_endpoint(
     None
 }
 
-fn read_endpoint(
-    handle: &mut DeviceHandle,
-    endpoint: Endpoint,
-    transfer_type: TransferType,
-) {
+fn read_endpoint(handle: &mut DeviceHandle, endpoint: Endpoint, transfer_type: TransferType) {
     println!("Reading from endpoint: {:?}", endpoint);
 
     let has_kernel_driver = match handle.kernel_driver_active(endpoint.iface) {
@@ -198,10 +192,7 @@ fn read_endpoint(
     }
 }
 
-fn configure_endpoint(
-    handle: &mut DeviceHandle,
-    endpoint: &Endpoint,
-) -> Result<()> {
+fn configure_endpoint(handle: &mut DeviceHandle, endpoint: &Endpoint) -> Result<()> {
     handle.set_active_configuration(endpoint.config)?;
     handle.claim_interface(endpoint.iface)?;
     handle.set_alternate_setting(endpoint.iface, endpoint.setting)?;

--- a/src/device.rs
+++ b/src/device.rs
@@ -12,7 +12,7 @@ use crate::{
     device_handle::DeviceHandle,
     error,
     fields::{self, Speed},
-    Error, Result, Context,
+    Context, Error, Result,
 };
 
 /// A reference to a USB device.

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -190,10 +190,7 @@ impl DeviceHandle {
     ///
     /// Converts an existing `libusb_device_handle` pointer into a `DeviceHandle`.
     /// `handle` must be a pointer to a valid `libusb_device_handle`. Rusb assumes ownership of the handle, and will close it on `drop`.
-    pub unsafe fn from_libusb(
-        context: Context,
-        handle: NonNull<libusb_device_handle>,
-    ) -> Self {
+    pub unsafe fn from_libusb(context: Context, handle: NonNull<libusb_device_handle>) -> Self {
         Self {
             context,
             handle: Some(handle),

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -1,6 +1,6 @@
 use libc::c_int;
 
-use std::{mem, ptr, slice};
+use std::{mem, slice};
 
 use crate::{
     context::Context,
@@ -27,22 +27,7 @@ impl Drop for DeviceList {
 
 impl DeviceList {
     pub fn new() -> Result<Self> {
-        let mut list = mem::MaybeUninit::<*const *mut libusb_device>::uninit();
-
-        let n =
-            unsafe { libusb_get_device_list(ptr::null_mut(), list.as_mut_ptr()) };
-
-        if n < 0 {
-            Err(error::from_libusb(n as c_int))
-        } else {
-            Ok(unsafe {
-                DeviceList {
-                    context: Default::default(),
-                    list: list.assume_init(),
-                    len: n as usize,
-                }
-            })
-        }
+        Self::new_with_context(Context::default())
     }
 
     pub fn new_with_context(context: Context) -> Result<Self> {

--- a/src/hotplug.rs
+++ b/src/hotplug.rs
@@ -1,13 +1,14 @@
 use crate::{
     constants::{
         LIBUSB_HOTPLUG_ENUMERATE, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED,
-            LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_NO_FLAGS,
+        LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_NO_FLAGS,
     },
+    error,
     ffi::{
         libusb_context, libusb_device, libusb_hotplug_callback_handle,
         libusb_hotplug_deregister_callback, libusb_hotplug_event, libusb_hotplug_register_callback,
     },
-    error, Result, Device, Context,
+    Context, Device, Result,
 };
 use std::{
     borrow::Borrow,
@@ -124,11 +125,7 @@ impl HotplugBuilder {
     /// [`Device`]: crate::Device
     /// [`DeviceHandle`]: crate::DeviceHandle
     /// [`Context::unregister_callback`]: method@crate::Context::unregister_callback
-    pub fn register(
-        self,
-        context: Context,
-        callback: Box<dyn Hotplug>,
-    ) -> Result<Registration> {
+    pub fn register(self, context: Context, callback: Box<dyn Hotplug>) -> Result<Registration> {
         let mut handle: libusb_hotplug_callback_handle = 0;
         let mut call_back = Box::new(CallbackData {
             context: context.borrow().clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,10 +97,7 @@ pub fn set_log_level(level: LogLevel) {
 ///
 /// Returns a device handle for the first device found matching `vendor_id` and `product_id`.
 /// On error, or if the device could not be found, it returns `None`.
-pub fn open_device_with_vid_pid(
-    vendor_id: u16,
-    product_id: u16,
-) -> Option<DeviceHandle> {
+pub fn open_device_with_vid_pid(vendor_id: u16, product_id: u16) -> Option<DeviceHandle> {
     let handle = unsafe {
         libusb1_sys::libusb_open_device_with_vid_pid(
             Context::global().as_raw(),
@@ -113,10 +110,7 @@ pub fn open_device_with_vid_pid(
         None
     } else {
         Some(unsafe {
-            DeviceHandle::from_libusb(
-                Context::global(),
-                std::ptr::NonNull::new_unchecked(handle),
-            )
+            DeviceHandle::from_libusb(Context::global(), std::ptr::NonNull::new_unchecked(handle))
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,10 @@ pub use libusb1_sys::constants;
 
 #[cfg(unix)]
 pub use crate::options::disable_device_discovery;
+
 pub use crate::{
     config_descriptor::{ConfigDescriptor, Interfaces},
-    context::{Context, GlobalContext, LogLevel, UsbContext},
+    context::{Context, LogLevel},
     device::Device,
     device_descriptor::DeviceDescriptor,
     device_handle::DeviceHandle,
@@ -51,39 +52,39 @@ mod options;
 
 /// Tests whether the running `libusb` library supports capability API.
 pub fn has_capability() -> bool {
-    GlobalContext::default().as_raw();
+    Context::global().as_raw();
     unsafe { libusb1_sys::libusb_has_capability(constants::LIBUSB_CAP_HAS_CAPABILITY) != 0 }
 }
 
 /// Tests whether the running `libusb` library supports hotplug.
 pub fn has_hotplug() -> bool {
-    GlobalContext::default().as_raw();
+    Context::global().as_raw();
     unsafe { libusb1_sys::libusb_has_capability(constants::LIBUSB_CAP_HAS_HOTPLUG) != 0 }
 }
 
 /// Tests whether the running `libusb` library has HID access.
 pub fn has_hid_access() -> bool {
-    GlobalContext::default().as_raw();
+    Context::global().as_raw();
     unsafe { libusb1_sys::libusb_has_capability(constants::LIBUSB_CAP_HAS_HID_ACCESS) != 0 }
 }
 
 /// Tests whether the running `libusb` library supports detaching the kernel driver.
 pub fn supports_detach_kernel_driver() -> bool {
-    GlobalContext::default().as_raw();
+    Context::global().as_raw();
     unsafe {
         libusb1_sys::libusb_has_capability(constants::LIBUSB_CAP_SUPPORTS_DETACH_KERNEL_DRIVER) != 0
     }
 }
 
 /// Returns a list of the current USB devices. Using global context
-pub fn devices() -> crate::Result<DeviceList<GlobalContext>> {
-    GlobalContext::default().devices()
+pub fn devices() -> crate::Result<DeviceList> {
+    Context::global().devices()
 }
 
 /// Sets the log level of a `libusb` global context.
 pub fn set_log_level(level: LogLevel) {
     unsafe {
-        libusb1_sys::libusb_set_debug(GlobalContext::default().as_raw(), level.as_c_int());
+        libusb1_sys::libusb_set_debug(Context::global().as_raw(), level.as_c_int());
     }
 }
 
@@ -99,10 +100,10 @@ pub fn set_log_level(level: LogLevel) {
 pub fn open_device_with_vid_pid(
     vendor_id: u16,
     product_id: u16,
-) -> Option<DeviceHandle<GlobalContext>> {
+) -> Option<DeviceHandle> {
     let handle = unsafe {
         libusb1_sys::libusb_open_device_with_vid_pid(
-            GlobalContext::default().as_raw(),
+            Context::global().as_raw(),
             vendor_id,
             product_id,
         )
@@ -113,7 +114,7 @@ pub fn open_device_with_vid_pid(
     } else {
         Some(unsafe {
             DeviceHandle::from_libusb(
-                GlobalContext::default(),
+                Context::global(),
                 std::ptr::NonNull::new_unchecked(handle),
             )
         })

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,4 @@
-use crate::{error, Result, Context};
+use crate::{error, Context, Result};
 use libusb1_sys::{constants::*, libusb_set_option};
 use std::ptr;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,5 +1,6 @@
-use crate::{error, UsbContext};
+use crate::{error, Result, Context};
 use libusb1_sys::{constants::*, libusb_set_option};
+use std::ptr;
 
 /// A `libusb` runtime option that can be enabled for a context.
 pub struct UsbOption {
@@ -19,7 +20,7 @@ impl UsbOption {
         }
     }
 
-    pub(crate) fn apply<T: UsbContext>(&self, ctx: &mut T) -> crate::Result<()> {
+    pub(crate) fn apply(&self, ctx: &mut Context) -> Result<()> {
         match self.inner {
             OptionInner::UseUsbdk => {
                 let err = unsafe { libusb_set_option(ctx.as_raw(), LIBUSB_OPTION_USE_USBDK) };
@@ -48,9 +49,9 @@ enum OptionInner {
 /// The option is useful in combination with [`Context::open_device_with_fd()`],
 /// which can access a device directly without prior device scanning.
 #[cfg(unix)]
-pub fn disable_device_discovery() -> crate::Result<()> {
+pub fn disable_device_discovery() -> Result<()> {
     try_unsafe!(libusb1_sys::libusb_set_option(
-        std::ptr::null_mut(),
+        ptr::null_mut(),
         LIBUSB_OPTION_NO_DEVICE_DISCOVERY
     ));
     Ok(())


### PR DESCRIPTION
Don't know if you would be interested in this as it is a big, breaking change...

This gets rid of the `UsbContext` trait and the `GlobalContext` as a separate type, and makes a single, concrete `Context` type. The global context is just a special instance of `Context` with a null inner pointer, which is lazily initialized when used.

You can get the global instance as the default `Context`:
```
let global_ctx = Context::default();
```
which is also aliased as `Context::global()`.

This simplifies the code pretty nicely, since you then don't need all the dependent types to be generic. `Device<T>` becomes `Device`; `DeviceList<T>` becomes `Device`, etc.