### PR TITLE
Fix package detection and build when cross-compiling from MSVC to GNU

### DIFF
--- a/libusb1-sys/Cargo.toml
+++ b/libusb1-sys/Cargo.toml
@@ -39,7 +39,7 @@ vendored = []
 [dependencies]
 libc = "0.2"
 
-[target.'cfg(target_env = "msvc")'.build-dependencies]
+[target.'cfg(target_os = "windows")'.build-dependencies]
 vcpkg = "0.2"
 
 [build-dependencies]


### PR DESCRIPTION
Hi!

I and @dragonmux found two issues when building libusb from a MSVC host to a MinGW target. When the build.rs script is built for the MSVC host,

- the vcpkg crate is used for detection (which correctly detects the MinGW target and reports an unsupported ABI)
- a MSVC flag is applied to the build (and thus breaking the build altogether)

This commit fixes both issues by changing vcpkg to a Windows-wide dependency, and then if CARGO_CFG_TARGET_ENV is indeed MSVC, it is used and the /source-charset:utf-8 flag is applied.

Please let us know what you think.