### PR TITLE
bLength, bDescriptorType and wTotalLength to descriptors

### DIFF
--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -94,6 +94,8 @@ fn print_device<T: UsbContext>(device_desc: &DeviceDescriptor, handle: &mut Opti
         };
 
     println!("Device Descriptor:");
+    println!("  bLength              {:3}", device_desc.length());
+    println!("  bDescriptorType      {:3}", device_desc.descriptor_type());
     println!(
         "  bcdUSB             {:2}.{}{}",
         device_desc.usb_version().major(),
@@ -147,6 +149,12 @@ fn print_device<T: UsbContext>(device_desc: &DeviceDescriptor, handle: &mut Opti
 
 fn print_config<T: UsbContext>(config_desc: &ConfigDescriptor, handle: &mut Option<UsbDevice<T>>) {
     println!("  Config Descriptor:");
+    println!("    bLength              {:3}", config_desc.length());
+    println!(
+        "    bDescriptorType      {:3}",
+        config_desc.descriptor_type()
+    );
+    println!("    wTotalLength      {:#06x}", config_desc.total_length());
     println!(
         "    bNumInterfaces       {:3}",
         config_desc.num_interfaces()
@@ -177,6 +185,11 @@ fn print_interface<T: UsbContext>(
     handle: &mut Option<UsbDevice<T>>,
 ) {
     println!("    Interface Descriptor:");
+    println!("      bLength              {:3}", interface_desc.length());
+    println!(
+        "      bDescriptorType      {:3}",
+        interface_desc.descriptor_type()
+    );
     println!(
         "      bInterfaceNumber     {:3}",
         interface_desc.interface_number()
@@ -219,6 +232,11 @@ fn print_interface<T: UsbContext>(
 
 fn print_endpoint(endpoint_desc: &EndpointDescriptor) {
     println!("      Endpoint Descriptor:");
+    println!("        bLength              {:3}", endpoint_desc.length());
+    println!(
+        "        bDescriptorType      {:3}",
+        endpoint_desc.descriptor_type()
+    );
     println!(
         "        bEndpointAddress    {:#04x} EP {} {:?}",
         endpoint_desc.address(),

--- a/src/config_descriptor.rs
+++ b/src/config_descriptor.rs
@@ -21,6 +21,21 @@ unsafe impl Sync for ConfigDescriptor {}
 unsafe impl Send for ConfigDescriptor {}
 
 impl ConfigDescriptor {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        unsafe { (*self.descriptor).bLength }
+    }
+
+    /// Returns the total length in bytes of data returned for this configuration: all interfaces and endpoints
+    pub fn total_length(&self) -> u16 {
+        unsafe { (*self.descriptor).wTotalLength }
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        unsafe { (*self.descriptor).bDescriptorType }
+    }
+
     /// Returns the configuration number.
     pub fn number(&self) -> u8 {
         unsafe { (*self.descriptor).bConfigurationValue }

--- a/src/device_descriptor.rs
+++ b/src/device_descriptor.rs
@@ -10,6 +10,16 @@ pub struct DeviceDescriptor {
 }
 
 impl DeviceDescriptor {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        self.descriptor.bLength
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        self.descriptor.bDescriptorType
+    }
+
     /// Returns the device's maximum supported USB version.
     pub fn usb_version(&self) -> Version {
         Version::from_bcd(self.descriptor.bcdUSB)

--- a/src/endpoint_descriptor.rs
+++ b/src/endpoint_descriptor.rs
@@ -10,6 +10,16 @@ pub struct EndpointDescriptor<'a> {
 }
 
 impl<'a> EndpointDescriptor<'a> {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        self.descriptor.bLength
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        self.descriptor.bDescriptorType
+    }
+
     /// Returns the endpoint's address.
     pub fn address(&self) -> u8 {
         self.descriptor.bEndpointAddress

--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -51,6 +51,16 @@ pub struct InterfaceDescriptor<'a> {
 }
 
 impl<'a> InterfaceDescriptor<'a> {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        self.descriptor.bLength
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        self.descriptor.bDescriptorType
+    }
+
     /// Returns the interface's number.
     pub fn interface_number(&self) -> u8 {
         self.descriptor.bInterfaceNumber


### PR DESCRIPTION
Adds getters for bLength, bDescriptorType and wTotalLength to descriptors. Includes them in list devices lsusb verbose example to make it more feature complete.

Is there a reason these are not present and I'm missing it? Rather than ask in an issue I thought it's more productive to add them and ask here.