### PR TITLE
Log callback API added

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use libusb1_sys::constants;
 pub use crate::options::disable_device_discovery;
 pub use crate::{
     config_descriptor::{ConfigDescriptor, Interfaces},
-    context::{Context, GlobalContext, LogLevel, UsbContext},
+    context::{Context, GlobalContext, LogCallbackMode, LogLevel, UsbContext},
     device::Device,
     device_descriptor::DeviceDescriptor,
     device_handle::DeviceHandle,


### PR DESCRIPTION
Good day.

This pr suggests some API updates to support log callbacks.

Log callback setup:
```
let mut context = rusb::Context::new()?;
context.set_log_level(rusb::LogLevel::Info);

let cb = Box::new(move |level: rusb::LogLevel, text: String| {
    println!(log_file, "[{:#?}] {}", level, text).ok();
});

context.set_log_callback(cb, rusb::LogCallbackMode::Context);
```

You can take this changes as a base for your own API or just merge it as is.
