### PR TITLE
fix: panic when trying to iterate over an interface with zero endpoints

### DIFF
--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -101,11 +101,9 @@ impl<'a> InterfaceDescriptor<'a> {
 
     /// Returns an iterator over the interface's endpoint descriptors.
     pub fn endpoint_descriptors(&self) -> EndpointDescriptors<'a> {
-        let endpoints = unsafe {
-            slice::from_raw_parts(
-                self.descriptor.endpoint,
-                self.descriptor.bNumEndpoints as usize,
-            )
+        let endpoints = match self.descriptor.bNumEndpoints {
+            0 => &[],
+            n => unsafe { slice::from_raw_parts(self.descriptor.endpoint, n as usize) },
         };
 
         EndpointDescriptors {


### PR DESCRIPTION
Some USB classes (UVC, UAC) provide alternate setting descriptors of interfaces with zero endpoints. Trying to call `endpoint_descriptors` on them caused a panic, because NULL was passed to `slice::from_raw_parts`. A branch was introduced to check for that case and create an iterator over an empty slice.

See: https://stackoverflow.com/a/49244874/2948315

Steps to reproduce the bug: 

1. Have a device connected which has an interface (or interface altsetting) with zero endpoints. (for example: `17ef:482f Lenovo Lenovo 500 RGB Camera`)
2. Run `RUST_BACKTRACE=1 cargo run --example list_devices` on the master branch
3. Observe panic:

<details>
<summary>Panic stacktrace</summary>

```
thread 'main' panicked at library/core/src/panicking.rs:155:5:
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
stack backtrace:
   0: rust_begin_unwind
             at /rustc/b381d3ab27f788f990551100c4425bb782d26d76/library/std/src/panicking.rs:647:5
   1: core::panicking::panic_nounwind_fmt::runtime
             at /rustc/b381d3ab27f788f990551100c4425bb782d26d76/library/core/src/panicking.rs:110:18
   2: core::panicking::panic_nounwind_fmt
             at /rustc/b381d3ab27f788f990551100c4425bb782d26d76/library/core/src/panicking.rs:122:9
   3: core::panicking::panic_nounwind
             at /rustc/b381d3ab27f788f990551100c4425bb782d26d76/library/core/src/panicking.rs:155:5
   4: core::slice::raw::from_raw_parts::precondition_check
             at /rustc/b381d3ab27f788f990551100c4425bb782d26d76/library/core/src/intrinsics.rs:2647:21
   5: core::slice::raw::from_raw_parts
             at /rustc/b381d3ab27f788f990551100c4425bb782d26d76/library/core/src/slice/raw.rs:98:9
   6: rusb::interface_descriptor::InterfaceDescriptor::endpoint_descriptors
             at ./src/interface_descriptor.rs:106:27
   7: list_devices::list_devices
             at ./examples/list_devices.rs:70:42
   8: list_devices::main
             at ./examples/list_devices.rs:16:5
   9: core::ops::function::FnOnce::call_once
             at /rustc/b381d3ab27f788f990551100c4425bb782d26d76/library/core/src/ops/function.rs:250:5
             
```
</details>

Details and software versions:

- rusb master branch (commit 15c2910463f71e97a04e3203feb6235c9e5c1f1d)
- libusb `1.0.27`
- `rustc 1.78.0-nightly (b381d3ab2 2024-02-12)`
- Linux kernel 6.7.8
