### PR TITLE
Add libusb_free_pollfds() in the available FFI methods.

### DIFF
--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -446,6 +446,7 @@ extern "system" {
         removed_cb: Option<libusb_pollfd_removed_cb>,
         user_data: *mut c_void,
     );
+    pub fn libusb_free_pollfds(pollfds: *const *mut libusb_pollfd);
     pub fn libusb_hotplug_register_callback(
         ctx: *mut libusb_context,
         events: c_int,


### PR DESCRIPTION
Merge request #197 as one commit as requested.

Since libusb_get_pollfds() is already available in the FFI, this PR adds the libusb_free_pollfds() method from libusb available in the FFI.

Libusb documentation of libusb_free_pollfds() states : "This should be called for all pollfd lists allocated with libusb_get_pollfds()"