### PR TITLE
Bump rusb 0.9.4 and libusb1-sys 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 0.9.4
+
+* bLength, bDescriptorType and wTotalLength to descriptors [#185]
+* Use &self reference for all DeviceHandle methods [#186]
+* fix: panic when trying to iterate over an interface with zero endpoints [#195]
+* Log callback API added [#194]
+* Bump libusb1-sys 0.7.0 [#205]
+
+[#185]: https://github.com/a1ien/rusb/pull/185
+[#186]: https://github.com/a1ien/rusb/pull/186
+[#195]: https://github.com/a1ien/rusb/pull/195
+[#194]: https://github.com/a1ien/rusb/pull/194
+[#205]: https://github.com/a1ien/rusb/pull/205
+
 ## 0.9.3
 * impl serde::{Serialize, Deserialize} for public enums [#167]
 * Update deprecated doc link about language identifiers [#165]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusb"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "Rust library for accessing USB devices."
 license = "MIT"
@@ -21,7 +21,7 @@ vendored = [ "libusb1-sys/vendored" ]
 members = ["libusb1-sys"]
 
 [dependencies]
-libusb1-sys = { path = "libusb1-sys", version = "0.6.4" }
+libusb1-sys = { path = "libusb1-sys", version = "0.7" }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/libusb1-sys/CHANGELOG.md
+++ b/libusb1-sys/CHANGELOG.md
@@ -1,6 +1,41 @@
 # Changes
 
-## unreleased
+## 0.7.0
+
+* fix: Add missing fields to libusb_bos_descriptor and libusb_bos_dev_capability_descriptor [#161]
+* Bump libusb to 1.0.27 [#201]
+* Remove unneeded mut [#204]
+
+[#161]: https://github.com/a1ien/rusb/pull/161
+[#201]: https://github.com/a1ien/rusb/pull/201
+[#204]: https://github.com/a1ien/rusb/pull/204
+
+## 0.6.5
+* Support pkg_config for MSVC. [#191]
+* Fix package detection and build when cross-compiling from MSVC to GNU [#180]
+* libusb_set_iso_packet_lengths panics on debug builds in newest nightly (2024-03-27) [#199]
+* Added libusb_free_pollfds() in the available FFI methods. [#203]
+
+[#191]: https://github.com/a1ien/rusb/pull/191
+[#180]: https://github.com/a1ien/rusb/pull/180
+[#199]: https://github.com/a1ien/rusb/pull/199
+[#203]: https://github.com/a1ien/rusb/pull/203
+
+## 0.6.3-0.6.4
+* Patch for macOS Big Sur and newer allowing to link statically [#133]
+* Add libudev include paths as specified by pkg-config [#140]
+
+[#133]: https://github.com/a1ien/rusb/pull/133
+[#140]: https://github.com/a1ien/rusb/pull/140
+
+
+## 0.6.2
+* Rename compiled library when vendored libusb is used [#130]
+
+[#130]: https://github.com/a1ien/rusb/pull/130
+
+## 0.6.1
+* Add LIBUSB_OPTION_NO_DEVICE_DISCOVERY constant
 * Bump vendored libusb version from 1.0.24 to 1.0.25 [#119]
 
 [#119]: https://github.com/a1ien/rusb/pull/119

--- a/libusb1-sys/Cargo.toml
+++ b/libusb1-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libusb1-sys"
-version = "0.6.4"
+version = "0.7.0"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>",
             "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "FFI bindings for libusb."


### PR DESCRIPTION
libusb 0.7.0

* fix: Add missing fields to libusb_bos_descriptor and libusb_bos_dev_capability_descriptor
* Bump libusb to 1.0.27
* Remove unneeded mut

rusb 0.9.4

* bLength, bDescriptorType and wTotalLength to descriptors
* Use &self reference for all DeviceHandle methods
* fix: panic when trying to iterate over an interface with zero endpoints
* Log callback API added
* Bump libusb1-sys 0.7.0