### PR TITLE
Android does not have udev; Do not link to udev on Android

### DIFF
--- a/libusb1-sys/build.rs
+++ b/libusb1-sys/build.rs
@@ -158,14 +158,16 @@ fn make_source() {
             Some("__attribute__((visibility(\"default\")))"),
         );
 
-        if let Ok(lib) = pkg_config::probe_library("libudev") {
-            base_config.define("USE_UDEV", Some("1"));
-            base_config.define("HAVE_LIBUDEV", Some("1"));
-            base_config.file(libusb_source.join("libusb/os/linux_udev.c"));
-            for path in lib.include_paths {
-                base_config.include(path.to_str().unwrap());
-            }
-        };
+        if std::env::var("CARGO_CFG_TARGET_OS") != Ok("android".into()) {
+            if let Ok(lib) = pkg_config::probe_library("libudev") {
+                base_config.define("USE_UDEV", Some("1"));
+                base_config.define("HAVE_LIBUDEV", Some("1"));
+                base_config.file(libusb_source.join("libusb/os/linux_udev.c"));
+                for path in lib.include_paths {
+                    base_config.include(path.to_str().unwrap());
+                }
+            };
+        }
 
         println!("Including posix!");
         base_config.file(libusb_source.join("libusb/os/events_posix.c"));


### PR DESCRIPTION
Android does not have udev; cross-compiling on a Linux host with udev results in a link to the same.

This patch refuses to enable udev if building for an android target.