### PR TITLE
fix: endpoint number parsing error

### DIFF
--- a/src/endpoint_descriptor.rs
+++ b/src/endpoint_descriptor.rs
@@ -159,7 +159,7 @@ mod test {
     #[test]
     fn it_ignores_reserved_bits_in_address() {
         assert_eq!(
-            0,
+            8,
             super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0000_1000)).number()
         );
         assert_eq!(
@@ -175,7 +175,7 @@ mod test {
             super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0100_0000)).number()
         );
         assert_eq!(
-            7,
+            0x0f,
             super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b1111_1111)).number()
         );
     }

--- a/src/endpoint_descriptor.rs
+++ b/src/endpoint_descriptor.rs
@@ -27,7 +27,7 @@ impl<'a> EndpointDescriptor<'a> {
 
     /// Returns the endpoint number.
     pub fn number(&self) -> u8 {
-        self.descriptor.bEndpointAddress & 0x07
+        self.descriptor.bEndpointAddress & 0x0f
     }
 
     /// Returns the endpoint's direction.


### PR DESCRIPTION
Fixed a bug in parsing the ndpoint number from the address field in endpoint descriptor. According to the USB device specification, bits 0-3 of the address field in the endpoint descriptor represent the endpoint number. Therefore, when parsing the number from the address, it should be masked with 0xf instead of 0x7. Incorrect parsing will lead to corrupted device endpoint information.